### PR TITLE
Fix github auth default scope

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,12 @@ config :phoenix_slime, :use_slim_extension, true
 
 config :ueberauth, Ueberauth,
   providers: [
-    github: { Ueberauth.Strategy.Github, [] }
+    github: { 
+      Ueberauth.Strategy.Github,
+      [
+        default_scope: "user:email"
+      ]
+     }
   ]
 
 config :ueberauth, Ueberauth.Strategy.Github.OAuth,


### PR DESCRIPTION
Подробности тут https://github.com/ueberauth/ueberauth_github/pull/32 и https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/

~Эту настройку протестировать не удалось, еще не разобрался в переборки проекта.~

~Авторизация теперь не работает, вероятно из за того, при текущих настройках, не приходит githug-login.~

- [x] Протестировать настройку требуемых прав от аккаунта-github
- [x] Разобраться почему с новыми настройками не работает авторизация


Настройка требуемых прав работает:

![authorize application](https://user-images.githubusercontent.com/761285/29293969-ca4332c8-8155-11e7-8fd2-a76defab4552.png)