### PR TITLE
Elo rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ make compose
 $ make compose-test
 ```
 
-### Usefull
+### Useful
 
 ```bash
 $ mix upload_lang

--- a/lib/codebattle/game_process/elo.ex
+++ b/lib/codebattle/game_process/elo.ex
@@ -1,0 +1,21 @@
+defmodule Codebattle.GameProcess.Elo do
+  @doc """
+    Calculates Elo rating
+
+  ## Examples
+
+    iex(1)> Codebattle.GameProcess.Elo.calc_elo(1000, 1000)
+    %{loser: 984, winner: 1016}
+  
+  """
+  def calc_elo(winner_rating, loser_rating, k \\ 32) do
+    %{
+      winner: winner_rating + k * winner_expected(winner_rating, loser_rating) |> round,
+      loser: loser_rating + k * loser_expected(winner_rating, loser_rating) |> round
+    }
+  end
+  
+  defp transform_rating(rating), do: :math.pow(10, ( rating / 400 ))
+  defp winner_expected(r1, r2), do: 1 - ( transform_rating(r1) / ( transform_rating(r1) + transform_rating(r2) ) )
+  defp loser_expected(r1, r2), do: 0 - ( transform_rating(r2) / ( transform_rating(r1) + transform_rating(r2) ) )
+end

--- a/lib/codebattle/game_process/elo.ex
+++ b/lib/codebattle/game_process/elo.ex
@@ -1,21 +1,32 @@
 defmodule Codebattle.GameProcess.Elo do
+  @moduledoc """
+    Elo
+  """
+
+  @kvalues %{
+    "elementary" => 16,
+    "easy" => 24,
+    "medium" => 32,
+    "hard" => 40
+  }
+
   @doc """
     Calculates Elo rating
 
   ## Examples
 
-    iex(1)> Codebattle.GameProcess.Elo.calc_elo(1000, 1000)
-    %{loser: 984, winner: 1016}
+    iex(1)> Codebattle.GameProcess.Elo.calc_elo(1000, 1000, 32)
+    {1016, 984}
   
   """
-  def calc_elo(winner_rating, loser_rating, k \\ 32) do
-    %{
-      winner: winner_rating + k * winner_expected(winner_rating, loser_rating) |> round,
-      loser: loser_rating + k * loser_expected(winner_rating, loser_rating) |> round
+  def calc_elo(winner_rating, loser_rating, difficulty \\ "medium") do
+    {
+      round(winner_rating + @kvalues[difficulty] * winner_expected(winner_rating, loser_rating)),
+      round(loser_rating + @kvalues[difficulty] * loser_expected(winner_rating, loser_rating))
     }
   end
   
-  defp transform_rating(rating), do: :math.pow(10, ( rating / 400 ))
-  defp winner_expected(r1, r2), do: 1 - ( transform_rating(r1) / ( transform_rating(r1) + transform_rating(r2) ) )
-  defp loser_expected(r1, r2), do: 0 - ( transform_rating(r2) / ( transform_rating(r1) + transform_rating(r2) ) )
+  defp transform_rating(rating), do: :math.pow(10, (rating / 400))
+  defp winner_expected(r1, r2), do: 1 - (transform_rating(r1) / (transform_rating(r1) + transform_rating(r2)))
+  defp loser_expected(r1, r2), do: 0 - (transform_rating(r2) / (transform_rating(r1) + transform_rating(r2)))
 end

--- a/lib/codebattle/game_process/play.ex
+++ b/lib/codebattle/game_process/play.ex
@@ -6,7 +6,7 @@ defmodule Codebattle.GameProcess.Play do
   import Ecto.Query, warn: false
 
   alias Codebattle.{Repo, Game, User, UserGame}
-  alias Codebattle.GameProcess.{Server, Supervisor, Fsm, Player, FsmHelpers}
+  alias Codebattle.GameProcess.{Server, Supervisor, Fsm, Player, FsmHelpers, Elo}
   alias Codebattle.CodeCheck.Checker
   alias Codebattle.Bot.RecorderServer
 
@@ -129,13 +129,13 @@ defmodule Codebattle.GameProcess.Play do
     # TODO: update users rating by Elo
       if user.id != 0 do
         user
-          |> User.changeset(%{rating: (user.rating + 10)})
+          |> User.changeset(%{ rating: Elo.calc_elo(user.rating, loser.rating).winner })
           |> Repo.update!
       end
 
       if loser.id != 0 do
         loser
-          |> User.changeset(%{rating: (loser.rating - 10)})
+          |> User.changeset(%{ rating: Elo.calc_elo(user.rating, loser.rating).loser })
           |> Repo.update!
       end
   end
@@ -153,13 +153,13 @@ defmodule Codebattle.GameProcess.Play do
 
       if user.id != 0 do
         user
-          |> User.changeset(%{rating: (user.rating + 10)})
+          |> User.changeset(%{ rating: Elo.calc_elo(winner.rating, user.rating).loser })
           |> Repo.update!
       end
 
       if winner.id != 0 do
         winner
-          |> User.changeset(%{rating: (winner.rating - 10)})
+          |> User.changeset(%{ rating: Elo.calc_elo(winner.rating, user.rating).winner })
           |> Repo.update!
       end
   end

--- a/lib/codebattle/game_process/play.ex
+++ b/lib/codebattle/game_process/play.ex
@@ -118,6 +118,9 @@ defmodule Codebattle.GameProcess.Play do
     # TODO: make async
     game_id = id |> Integer.parse |> elem(0)
     loser = FsmHelpers.get_opponent(fsm.data, user.id)
+    difficulty = fsm.data.task.level
+
+    {winner_rating, loser_rating} = Elo.calc_elo(user.rating, loser.rating, difficulty)
 
     game_id
       |> get_game
@@ -129,13 +132,13 @@ defmodule Codebattle.GameProcess.Play do
     # TODO: update users rating by Elo
       if user.id != 0 do
         user
-          |> User.changeset(%{ rating: Elo.calc_elo(user.rating, loser.rating).winner })
+          |> User.changeset(%{rating: winner_rating})
           |> Repo.update!
       end
 
       if loser.id != 0 do
         loser
-          |> User.changeset(%{ rating: Elo.calc_elo(user.rating, loser.rating).loser })
+          |> User.changeset(%{rating: loser_rating})
           |> Repo.update!
       end
   end
@@ -143,6 +146,9 @@ defmodule Codebattle.GameProcess.Play do
   defp handle_gave_up(id, user, fsm) do
     game_id = id |> Integer.parse |> elem(0)
     winner = FsmHelpers.get_opponent(fsm.data, user.id)
+    difficulty = fsm.data.task.level
+
+    {winner_rating, loser_rating} = Elo.calc_elo(winner.rating, user.rating, difficulty)
 
     game_id
       |> get_game
@@ -153,13 +159,13 @@ defmodule Codebattle.GameProcess.Play do
 
       if user.id != 0 do
         user
-          |> User.changeset(%{ rating: Elo.calc_elo(winner.rating, user.rating).loser })
+          |> User.changeset(%{rating: loser_rating})
           |> Repo.update!
       end
 
       if winner.id != 0 do
         winner
-          |> User.changeset(%{ rating: Elo.calc_elo(winner.rating, user.rating).winner })
+          |> User.changeset(%{rating: winner_rating})
           |> Repo.update!
       end
   end

--- a/lib/codebattle_web/channels/game_channel.ex
+++ b/lib/codebattle_web/channels/game_channel.ex
@@ -70,7 +70,6 @@ defmodule CodebattleWeb.GameChannel do
     end
   end
 
-
   def handle_in("check_result", payload, socket) do
     game_id = get_game_id(socket)
     if user_authorized_in_game?(game_id, socket.assigns.user_id) do

--- a/test/codebattle/bot/playbook_play_test.exs
+++ b/test/codebattle/bot/playbook_play_test.exs
@@ -47,12 +47,12 @@ defmodule Codebattle.Bot.PlaybookPlayTest do
       assert fsm.state == :waiting_opponent
 
       #bot join game
-      :timer.sleep(150)
+      :timer.sleep(400)
       fsm = Server.fsm(game_id)
       assert FsmHelpers.get_second_player(fsm).editor_text == "tes"
 
       #bot win the game
-      :timer.sleep(150)
+      :timer.sleep(300)
       fsm = Server.fsm(game_id)
 
       assert fsm.state == :player_won

--- a/test/codebattle_web/channels/game_channel_test.exs
+++ b/test/codebattle_web/channels/game_channel_test.exs
@@ -133,7 +133,7 @@ defmodule CodebattleWeb.GameChannelTest do
   test "on give up opponents win when state playing", %{user1: user1, user2: user2, socket1: socket1, socket2: socket2} do
     #setup
     state = :playing
-    data = %{players: [%Player{id: user1.id, user: user1}, %Player{id: user2.id, user: user2}]}
+    data = %{task: build(:task), players: [%Player{id: user1.id, user: user1}, %Player{id: user2.id, user: user2}]}
     game = setup_game(state, data)
     game_topic = "game:" <> to_string(game.id)
 
@@ -163,8 +163,8 @@ defmodule CodebattleWeb.GameChannelTest do
     user2 = Repo.get(User, user2.id)
 
     assert game.state == "game_over"
-    assert user1.rating == 984
-    assert user2.rating == 1016
+    assert user1.rating == 988
+    assert user2.rating == 1012
   end
 end
 

--- a/test/codebattle_web/channels/game_channel_test.exs
+++ b/test/codebattle_web/channels/game_channel_test.exs
@@ -5,8 +5,8 @@ defmodule CodebattleWeb.GameChannelTest do
   alias Codebattle.GameProcess.{Player, Server, FsmHelpers}
 
   setup do
-    user1 = insert(:user, rating: 10)
-    user2 = insert(:user, rating: 10)
+    user1 = insert(:user, rating: 1000)
+    user2 = insert(:user, rating: 1000)
     task = insert(:task)
 
     user_token1 = Phoenix.Token.sign(socket(), "user_token", user1.id)
@@ -154,8 +154,8 @@ defmodule CodebattleWeb.GameChannelTest do
     fsm = Server.fsm(game.id)
 
     assert fsm.state == :game_over
-    assert FsmHelpers.winner?(fsm.data, user2.id) == true
     assert FsmHelpers.gave_up?(fsm.data, user1.id) == true
+    assert FsmHelpers.winner?(fsm.data, user2.id) == true
     :timer.sleep(100)
 
     game = Repo.get Game, game.id
@@ -163,8 +163,8 @@ defmodule CodebattleWeb.GameChannelTest do
     user2 = Repo.get(User, user2.id)
 
     assert game.state == "game_over"
-    assert user1.rating == 20
-    assert user2.rating == 0
+    assert user1.rating == 984
+    assert user2.rating == 1016
   end
 end
 

--- a/test/codebattle_web/integration/play_game_test.exs
+++ b/test/codebattle_web/integration/play_game_test.exs
@@ -9,9 +9,9 @@ defmodule Codebattle.PlayGameTest do
 
   setup do
     insert(:task)
-    user1 = insert(:user, %{name: "first", email: "test1@test.test", github_id: 1, rating: 10})
-    user2 = insert(:user, %{name: "second", email: "test2@test.test", github_id: 2, rating: 10})
-    user3 = insert(:user, %{name: "other", email: "test3@test.test", github_id: 3, rating: 10})
+    user1 = insert(:user, %{name: "first", email: "test1@test.test", github_id: 1, rating: 1000})
+    user2 = insert(:user, %{name: "second", email: "test2@test.test", github_id: 2, rating: 1000})
+    user3 = insert(:user, %{name: "other", email: "test3@test.test", github_id: 3, rating: 1000})
     conn1 = assign(build_conn(), :user, user1)
     conn2 = assign(build_conn(), :user, user2)
     conn3 = assign(build_conn(), :user, user3)
@@ -101,8 +101,8 @@ defmodule Codebattle.PlayGameTest do
       user2 = Repo.get(User, user2.id)
 
       assert game.state == "game_over"
-      assert user1.rating == 20
-      assert user2.rating == 0
+      assert user1.rating == 1016
+      assert user2.rating == 984
     end
   end
 

--- a/test/codebattle_web/integration/play_game_test.exs
+++ b/test/codebattle_web/integration/play_game_test.exs
@@ -101,8 +101,8 @@ defmodule Codebattle.PlayGameTest do
       user2 = Repo.get(User, user2.id)
 
       assert game.state == "game_over"
-      assert user1.rating == 1016
-      assert user2.rating == 984
+      assert user1.rating == 1012
+      assert user2.rating == 988
     end
   end
 


### PR DESCRIPTION
Решил в качестве разминки внести вклад в подсчёт Эло рейтинга

В codebattle/game_process поселил elo.ex, там живёт функция calc_elo с арностью 3, аргументы: winner_rating, loser_rating, k, где первые два — рейтинги игроков, а k — ценность игры, на выходе ассоциативный массив вида %{winner: <rating>, loser: <rating>}.

k по умолчанию равен 32 (по примеру ICC), в дальнейшем над ним можно будет дополнительно поколдовать

Кстати, кнопка “сдаться” была отличным способом набить рейтинг ибо добавляла очки не той стороне, ну и убавляла тоже, но я эту лавочку прикрыл :D

Тесты с участием рейтинга подправил, локально всё вполне успешно запустилось, так что по идее ничего не сломал.
  