### PR TITLE
In order to show current game time, use joins_at attribute istead of

### DIFF
--- a/services/app/assets/js/widgets/containers/InfoWidget.jsx
+++ b/services/app/assets/js/widgets/containers/InfoWidget.jsx
@@ -5,12 +5,12 @@ import Task from '../components/Task';
 import * as selectors from '../selectors';
 
 const InfoWidget = (props) => {
-  const { taskText, gameStatusName, startsAt } = props;
+  const { taskText, gameStatusName, joinsAt } = props;
 
   return (
     <div className="row no-gutters">
       <div className="col-12 col-lg-6 p-1">
-        <Task task={taskText} time={startsAt} gameStatusName={gameStatusName} />
+        <Task task={taskText} time={joinsAt} gameStatusName={gameStatusName} />
       </div>
       <div className="col-12 col-lg-6 p-1">
         <ChatWidget />
@@ -20,11 +20,14 @@ const InfoWidget = (props) => {
 };
 
 
-const mapStateToProps = state => ({
-  taskText: selectors.gameTaskSelector(state),
-  gameStatusName: selectors.gameStatusNameSelector(state),
-  startsAt: selectors.gameStartsAtSelector(state),
-  // outputText: state.executionOutput,
-});
+const mapStateToProps = (state) => {
+  const gameStatus = selectors.gameStatusSelector(state);
+
+  return {
+    taskText: selectors.gameTaskSelector(state),
+    joinsAt: gameStatus.joinsAt,
+    gameStatusName: gameStatus.status,
+  };
+};
 
 export default connect(mapStateToProps)(InfoWidget);

--- a/services/app/assets/js/widgets/containers/NotificationsHandler.jsx
+++ b/services/app/assets/js/widgets/containers/NotificationsHandler.jsx
@@ -123,7 +123,7 @@ class NotificationsHandler extends Component {
     toast(
       <Toast header="Success">
         <Alert variant="success">
-          {`${winner.user_name} has won the game!`}
+          {`${winner.name} has won the game!`}
         </Alert>
       </Toast>,
     );

--- a/services/app/assets/js/widgets/middlewares/Game.js
+++ b/services/app/assets/js/widgets/middlewares/Game.js
@@ -15,9 +15,11 @@ const initGameChannel = (dispatch) => {
     const {
       status,
       starts_at: startsAt,
+      joins_at: joinsAt,
       players: [firstPlayer, secondPlayer],
       task,
     } = response;
+
 
     // const firstEditorLang = _.find(languages, { slug: user1.editor_lang });
     // const users = [{ ...user1, type: userTypes.firstPlayer }];
@@ -64,7 +66,7 @@ const initGameChannel = (dispatch) => {
     if (task) {
       dispatch(actions.setGameTask({ task }));
     }
-    dispatch(actions.updateGameStatus({ status, startsAt }));
+    dispatch(actions.updateGameStatus({ status, startsAt, joinsAt }));
     dispatch(actions.finishStoreInit());
   };
 
@@ -166,6 +168,7 @@ export const editorReady = () => (dispatch) => {
   channel.on('user:joined', ({
     status,
     starts_at: startsAt,
+    joins_at: joinsAt,
     players: [firstPlayer, secondPlayer],
     task,
   }) => {
@@ -203,7 +206,7 @@ export const editorReady = () => (dispatch) => {
       }));
     }
 
-    dispatch(actions.updateGameStatus({ status, startsAt }));
+    dispatch(actions.updateGameStatus({ status, startsAt, joinsAt }));
   });
 
   channel.on('user:won', ({ players, status, msg }) => {

--- a/services/app/assets/js/widgets/selectors/index.js
+++ b/services/app/assets/js/widgets/selectors/index.js
@@ -88,9 +88,6 @@ export const gameStatusTitleSelector = (state) => {
 };
 
 export const gameTaskSelector = state => state.game.task;
-export const gameStatusNameSelector = state => state.game.gameStatus.status;
-
-export const gameStartsAtSelector = state => state.game.gameStatus.startsAt;
 
 export const gameLangsSelector = state => state.game.langs;
 

--- a/services/app/lib/codebattle/game_process/fsm_helpers.ex
+++ b/services/app/lib/codebattle/game_process/fsm_helpers.ex
@@ -58,6 +58,10 @@ defmodule Codebattle.GameProcess.FsmHelpers do
     fsm.data.starts_at
   end
 
+  def get_joins_at(fsm) do
+    fsm.data.joins_at
+  end
+
   def get_task(fsm) do
     fsm.data.task
   end

--- a/services/app/lib/codebattle/game_process/play.ex
+++ b/services/app/lib/codebattle/game_process/play.ex
@@ -41,7 +41,8 @@ defmodule Codebattle.GameProcess.Play do
       players: FsmHelpers.get_players(fsm),
       task: FsmHelpers.get_task(fsm),
       level: FsmHelpers.get_level(fsm),
-      type: FsmHelpers.get_type(fsm)
+      type: FsmHelpers.get_type(fsm),
+      joins_at: FsmHelpers.get_joins_at(fsm)
     }
   end
 

--- a/services/app/lib/codebattle_web/channels/game_channel.ex
+++ b/services/app/lib/codebattle_web/channels/game_channel.ex
@@ -17,7 +17,7 @@ defmodule CodebattleWeb.GameChannel do
     game_id = get_game_id(socket)
     game_info = Play.game_info(game_id)
 
-    fields = [:status, :players, :task, :starts_at, :level]
+    fields = [:status, :players, :task, :starts_at, :joins_at, :level]
 
     broadcast_from!(socket, "user:joined", Map.take(game_info, fields))
     {:noreply, socket}


### PR DESCRIPTION
In order to show current game time, use joins_at attribute istead of starts_at. Starts_at show the date when game was created, while joins_at - the time when it actually started (second played joined)

Ну, собственно, нет никакого смысла показывать сколько времени прошло с даты создания игры. Надо показывать сколько она длится. 

![image](https://user-images.githubusercontent.com/1745708/55685774-ac116900-5962-11e9-9144-4070e933566b.png)
