### PR TITLE
fix header tournir's layout on tablet devices

### DIFF
--- a/services/app/lib/codebattle_web/templates/tournament/_header.html.slimleex
+++ b/services/app/lib/codebattle_web/templates/tournament/_header.html.slimleex
@@ -1,13 +1,13 @@
 .container-fluid
   .row
-    .col
+    .col-8
       h1
-        = @tournament.name |> String.upcase
-        span.small.text-muted.ml-3 = @tournament.state
+        span.mr-3 = @tournament.name |> String.upcase
+        span.small.text-muted = @tournament.state
       = if @tournament.state == "waiting_participants" do
         p  Will start in #{@time.minutes} minutes #{@time.seconds} seconds
 
-    .col
+    .col-4
       .text-right
         = if is_creator?(@tournament, @current_user.id) do
           button.btn.btn-outline-success.mx-2[phx-click="start"] Start


### PR DESCRIPTION
Просто маленькое улучшение шапки, порой заголовок не входил в "размер"
Просто немного увеличил его контейнер + поправил отступ, чтобы в случае переноса текст выстраивался в ряд