### PR TITLE
Add flake8 linter for Python

### DIFF
--- a/services/app/dockers/python/Dockerfile
+++ b/services/app/dockers/python/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.7.2
 
 RUN apt-get update && apt-get install -y build-essential --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN pip3 install wemake-python-styleguide
 
 WORKDIR /usr/src/app
 
 ADD checker_example.py .
 ADD solution_example.py .
 ADD Makefile .
+ADD setup.cfg .

--- a/services/app/dockers/python/Makefile
+++ b/services/app/dockers/python/Makefile
@@ -4,8 +4,11 @@ test:
 test-example:
 	python checker_example.py
 
+lint:
+	flake8 ./check/solution.py
+
 lint_example:
-	echo "lint_example"
+	flake8 ./solution_example.py
 
 docker_build_image:
 	docker build -t codebattle/python --file ./Dockerfile ./

--- a/services/app/dockers/python/setup.cfg
+++ b/services/app/dockers/python/setup.cfg
@@ -1,0 +1,27 @@
+[coverage:run]
+branch = True
+
+[flake8]
+accept-encodings = utf-8
+max-complexity = 6
+statistics = False
+max-line-length = 80
+doctests = True
+enable-extensions = G
+isort-show-traceback = True
+
+ignore =
+  # it is ok to have some magical numbers here
+  Z432
+
+[tool:pytest]
+norecursedirs = __pycache__
+addopts = --strict
+
+[isort]
+# See https://github.com/timothycrosley/isort#multi-line-output-modes
+multi_line_output = 3
+include_trailing_comma = true
+default_section = FIRSTPARTY
+# Should be: 80 - 1
+line_length = 79


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) #578
For test run: cd service/app/dockers/python && make docker_build_image docker_run_lint_example