### PR TITLE
632 add new output for code runners

### DIFF
--- a/services/app/dockers/elixir/Makefile
+++ b/services/app/dockers/elixir/Makefile
@@ -1,7 +1,7 @@
 test:
 	mix run ./check/checker.exs
 
-test_example:
+test-example:
 	mix run checker_example.exs
 
 .PHONY: test

--- a/services/app/dockers/js/Dockerfile
+++ b/services/app/dockers/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.6.0
+FROM node:13.8.0
 
 RUN apt-get update && apt-get install -y build-essential --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/services/app/dockers/js/Makefile
+++ b/services/app/dockers/js/Makefile
@@ -1,7 +1,7 @@
 test:
 	babel --out-dir ./check/dist ./check/ && node ./check/dist/checker.js
 
-test_example:
+test-example:
 	babel --out-dir dist ./ && node ./dist/checker_example.js
 
 .PHONY: test

--- a/services/app/dockers/js/checker_example.js
+++ b/services/app/dockers/js/checker_example.js
@@ -1,46 +1,54 @@
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
 const chai = require('chai');
 
 const { assert } = chai;
+const buildRespose = data => `${JSON.stringify(data)}\n`;
 
 let success = true;
+let output = '';
+const finalResult = [];
+
+process.stdout.write = (chunk, encoding, callback) => {
+  if (typeof chunk === 'string') {
+    output += chunk;
+  }
+};
 
 try {
   // We can change solution to check different behaviors
   const solution = require('./solution_example');
   // const solution = require('./solution');
 
-  const assertSolution = (result, expected, errorMessage) => {
+  output = '';
+
+  const assertSolution = (result, expected, arguments) => {
     try {
       assert.deepEqual(result, expected);
-
-      process.stdout.write(`${JSON.stringify({
-        status: 'success',
-        result,
-      })}\n`);
+      finalResult.push(buildRespose({ status: 'success', result, output, expected, arguments }));
     } catch (e) {
-      process.stdout.write(`${JSON.stringify({
-        status: 'failure',
-        result,
-        arguments: errorMessage,
-      })}\n`);
+      finalResult.push(
+        buildRespose({
+          status: 'failure',
+          result,
+          output,
+          expected,
+          arguments,
+        }),
+      );
       success = false;
     }
+    output = '';
   };
 
   assertSolution(solution(1, 2), 3, [1, 2]); // arguments1, expected1
   assertSolution(solution(5, 6), 11, [5, 6]); // arguments2, expected2
 
   if (success) {
-    process.stdout.write(`${JSON.stringify({
-      status: 'ok',
-      result: '__code0.0__',
-    })}\n`);
+    finalResult.push(buildRespose({ status: 'ok', result: '__code0.0__' }));
   }
-  process.exit(0);
 } catch (e) {
-  process.stdout.write(`${JSON.stringify({
-    status: 'error',
-    result: e.message,
-  })}\n`);
-  process.exit(0);
+  finalResult.push(buildRespose({ status: 'error', output: e.message }));
 }
+
+process.stdout.write = originalStdoutWrite;
+process.stdout.write(finalResult.join());

--- a/services/app/dockers/js/solution_example.js
+++ b/services/app/dockers/js/solution_example.js
@@ -1,6 +1,7 @@
 const reduce = fn => arr => arr.reduce(fn);
 
 module.exports = (a, b) => (
-  console.log(a);
+  console.log(a),
+  console.log(b),
   [a, b] |> reduce((acc, x) => acc + x)
 );

--- a/services/app/dockers/js/solution_example.js
+++ b/services/app/dockers/js/solution_example.js
@@ -1,6 +1,6 @@
 const reduce = fn => arr => arr.reduce(fn);
 
 module.exports = (a, b) => (
+  console.log(a);
   [a, b] |> reduce((acc, x) => acc + x)
 );
-

--- a/services/app/dockers/python/solution_example.py
+++ b/services/app/dockers/python/solution_example.py
@@ -1,2 +1,3 @@
 def solution(a: int, b: int)-> int:
+    print(a)
     return a + b

--- a/services/app/dockers/ruby/Makefile
+++ b/services/app/dockers/ruby/Makefile
@@ -1,7 +1,7 @@
 test:
 	ruby ./check/checker.rb
 
-test_example:
+test-example:
 	ruby checker_example.rb
 
 .PHONY: test

--- a/services/app/dockers/ruby/checker_example.rb
+++ b/services/app/dockers/ruby/checker_example.rb
@@ -14,8 +14,11 @@ begin
 
   success = true
 
-  def assert_result(result, expected, arguments, success)
+  def assert_result(solution, expected, arguments, success)
     begin
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = solution.call(*arguments)
+      finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       assert_equal(expected, result)
 
       @execution_result <<
@@ -24,7 +27,8 @@ begin
           result: result,
           output: $stdout.string,
           expected: expected,
-          arguments: arguments
+          arguments: arguments,
+          execution_time: finish - start
         )
       success
     rescue Test::Unit::AssertionFailedError
@@ -34,14 +38,15 @@ begin
           result: result,
           output: $stdout.string,
           expected: expected,
-          arguments: arguments
+          arguments: arguments,
+          execution_time: finish - start
         )
       false
     end
   end
 
-  success = assert_result(method(:solution).call(1, 2), 3, [1, 2], success)
-  success = assert_result(method(:solution).call(5, 3), 8, [5, 3], success)
+  success = assert_result(method(:solution), 3, [1, 2], success)
+  success = assert_result(method(:solution), 8, [5, 3], success)
   if success
     @execution_result <<
       JSON.dump(

--- a/services/app/dockers/ruby/checker_example.rb
+++ b/services/app/dockers/ruby/checker_example.rb
@@ -1,46 +1,61 @@
 require 'json'
+require 'stringio'
 require 'test/unit'
-$stdout = STDERR
 
 extend Test::Unit::Assertions
+
+original_stdout = $stdout
+$stdout = StringIO.new
+
+@execution_result = []
 
 begin
   require './solution_example'
 
   success = true
 
-  def assert_result(result, expected, error_message, success)
+  def assert_result(result, expected, arguments, success)
     begin
       assert_equal(expected, result)
 
-      puts JSON.dump(
-        status: :success,
-        result: result
-      )
+      @execution_result <<
+        JSON.dump(
+          status: :success,
+          result: result,
+          output: $stdout.string,
+          expected: expected,
+          arguments: arguments
+        )
       success
     rescue Test::Unit::AssertionFailedError
-      puts JSON.dump(
-        status: :failure,
-        result: result,
-        arguments: error_message
-      )
+      @execution_result <<
+        JSON.dump(
+          status: :failure,
+          result: result,
+          output: $stdout.string,
+          expected: expected,
+          arguments: arguments
+        )
       false
     end
   end
 
   success = assert_result(method(:solution).call(1, 2), 3, [1, 2], success)
   success = assert_result(method(:solution).call(5, 3), 8, [5, 3], success)
-
   if success
-    puts JSON.dump(
-      status: :ok,
-      result: '__code-0__'
-    )
+    @execution_result <<
+      JSON.dump(
+        status: :ok,
+        result: '__code-0__'
+      )
   end
 rescue Exception => e
-  puts(JSON.dump(
-         status: :error,
-         result: e.message
-       ))
-  exit(0)
+  @execution_result <<
+    JSON.dump(
+      status: :error,
+      result: e.message
+    )
 end
+
+$stdout = original_stdout
+puts @execution_result

--- a/services/app/dockers/ruby/solution_example.rb
+++ b/services/app/dockers/ruby/solution_example.rb
@@ -1,3 +1,4 @@
 def solution(a, b)
+  puts a
   a + b
 end

--- a/services/app/dockers/ts/Makefile
+++ b/services/app/dockers/ts/Makefile
@@ -1,7 +1,7 @@
 test:
 	tsc --project tsconfig.json && node ./check/checker.js
 
-test_example:
+test-example:
 	tsc --project tsconfig_example.json && node ./checker_example.js
 
 .PHONY: test

--- a/services/app/lib/codebattle/languages.ex
+++ b/services/app/lib/codebattle/languages.ex
@@ -62,11 +62,11 @@ defmodule Codebattle.Languages do
       "js" => %{
         name: "Node.js",
         slug: "js",
-        version: "11.6.0",
+        version: "13.8.0",
         base_image: :ubuntu,
         check_dir: "check",
         extension: "js",
-        docker_image: "codebattle/js:11.6.0",
+        docker_image: "codebattle/js:13.8.0",
         solution_version: :default,
         solution_template:
           "const _ = require(\"lodash\");\nconst R = require(\"rambda\");\n\nmodule.exports = (<%= arguments %>) => {\n<%= return_statement %>\n};",

--- a/services/app/priv/templates/js.eex
+++ b/services/app/priv/templates/js.eex
@@ -4,6 +4,8 @@ const chai = require('chai');
 const { assert } = chai;
 const buildRespose = data => `${JSON.stringify(data)}\n`;
 
+const NS_PER_SEC = 1e9;
+
 let success = true;
 let output = '';
 const finalResult = [];
@@ -20,10 +22,21 @@ try {
   // const solution = require('./solution');
 
   output = '';
-  const assertSolution = (result, expected, arguments) => {
+  const assertSolution = (solutionLambda, expected, args) => {
+    const start = process.hrtime()
+    const result = solutionLambda(args)
+    const diff = process.hrtime(start) // returns [seconds, nanoseconds]
+    const executionTime = diff[0] + diff[1] / NS_PER_SEC;
     try {
       assert.deepEqual(result, expected);
-      finalResult.push(buildRespose({ status: 'success', result, output, expected, arguments }));
+      finalResult.push(buildRespose({
+        status: 'success',
+        result,
+        output,
+        expected,
+        arguments: args,
+        execution_time: executionTime,
+      }));
     } catch (e) {
       finalResult.push(
         buildRespose({
@@ -31,7 +44,8 @@ try {
           result,
           output,
           expected,
-          arguments,
+          arguments: args,
+          execution_time: executionTime,
         }),
       );
       success = false;
@@ -39,13 +53,16 @@ try {
     output = '';
   };
 
+  const solutionLambda = args => { return solution(...args); };
   <%= for %{arguments: arguments, expected: expected} <- checks do %>
-    assertSolution(solution(<%= arguments %>), <%= expected %>, [<%= arguments %>]);
+    assertSolution(solutionLambda, <%= expected %>, [<%= arguments %>]);
   <% end %>
 
 
   if (success) {
-    finalResult.push(buildRespose({ status: 'ok', result: '__code0.0__' }));
+    finalResult.push(
+      buildRespose({ status: 'ok', result: <%= hash_sum %> })
+    );
   }
 } catch (e) {
   finalResult.push(buildRespose({ status: 'error', output: e.message }));

--- a/services/app/priv/templates/js.eex
+++ b/services/app/priv/templates/js.eex
@@ -1,47 +1,55 @@
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
 const chai = require('chai');
 
 const { assert } = chai;
+const buildRespose = data => `${JSON.stringify(data)}\n`;
 
 let success = true;
+let output = '';
+const finalResult = [];
+
+process.stdout.write = (chunk, encoding, callback) => {
+  if (typeof chunk === 'string') {
+    output += chunk;
+  }
+};
 
 try {
   // We can change solution to check different behaviors
   const solution = require('./solution');
   // const solution = require('./solution');
 
-  const assertSolution = (result, expected, errorMessage) => {
+  output = '';
+  const assertSolution = (result, expected, arguments) => {
     try {
       assert.deepEqual(result, expected);
-
-      process.stdout.write(`${JSON.stringify({
-        status: 'success',
-        result,
-      })}\n`);
+      finalResult.push(buildRespose({ status: 'success', result, output, expected, arguments }));
     } catch (e) {
-      process.stdout.write(`${JSON.stringify({
-        status: 'failure',
-        result,
-        arguments: errorMessage,
-      })}\n`);
+      finalResult.push(
+        buildRespose({
+          status: 'failure',
+          result,
+          output,
+          expected,
+          arguments,
+        }),
+      );
       success = false;
     }
+    output = '';
   };
 
   <%= for %{arguments: arguments, expected: expected} <- checks do %>
     assertSolution(solution(<%= arguments %>), <%= expected %>, [<%= arguments %>]);
   <% end %>
 
+
   if (success) {
-    process.stdout.write(`${JSON.stringify({
-      status: 'ok',
-      result: <%= hash_sum %>,
-    })}\n`);
+    finalResult.push(buildRespose({ status: 'ok', result: '__code0.0__' }));
   }
-  process.exit(0);
 } catch (e) {
-  process.stdout.write(`${JSON.stringify({
-    status: 'error',
-    result: e.message,
-  })}\n`);
-  process.exit(0);
+  finalResult.push(buildRespose({ status: 'error', output: e.message }));
 }
+
+process.stdout.write = originalStdoutWrite;
+process.stdout.write(finalResult.join());

--- a/services/app/priv/templates/python.eex
+++ b/services/app/priv/templates/python.eex
@@ -1,19 +1,36 @@
 import sys
 import json
+import time
+from io import StringIO
 
-def assert_result(result, expected, errorMessage, success):
+original_stdout = sys.stdout
+sys.stdout = StringIO()
+
+execution_result = []
+
+def assert_result(solution, expected, arguments, success):
     try:
-        assert result == expected, errorMessage
-        print(json.dumps({
+        start = time.clock()
+        result = solution(arguments)
+        finish = time.clock()
+        assert result == expected
+        execution_result.append(json.dumps({
             'status': 'success',
             'result': result,
+            'output': sys.stdout.getvalue(),
+            'expected': expected,
+            'arguments': arguments,
+            'execution_time': finish - start
         }))
         return success
     except AssertionError as exc:
-        print(json.dumps({
+        execution_result.append(json.dumps({
             'status': 'failure',
             'result': result,
-            'arguments': errorMessage,
+            'output': sys.stdout.getvalue(),
+            'expected': expected,
+            'arguments': arguments,
+            'execution_time': finish - start
         }))
         return False
 
@@ -21,18 +38,20 @@ try:
     from solution import solution
     success = True
     <%= for %{arguments: arguments, expected: expected} <- checks do %>
-    success = assert_result(solution(<%= arguments %>), <%= expected %>, [<%= arguments %>], success)
+    solution_lambda = lambda arguments: solution(*arguments)
+    success = assert_result(solution_lambda, <%= expected %>, [<%= arguments %>], success)
     <% end %>
 
     if success:
-        print(json.dumps({
+        execution_result.append(json.dumps({
             'status': 'ok',
             'result': <%= hash_sum %>,
         }))
-    exit(0)
 except Exception as exc:
-    print(json.dumps({
+    execution_result.append(json.dumps({
         'status': 'error',
         'result': exc.args,
     }))
-    exit(0)
+
+sys.stdout = original_stdout
+print(execution_result)

--- a/services/app/priv/templates/ruby.eex
+++ b/services/app/priv/templates/ruby.eex
@@ -41,8 +41,6 @@ begin
           arguments: arguments,
           execution_time: finish - start
         )
-      success
-        )
       false
     end
   end

--- a/services/app/priv/templates/ruby.eex
+++ b/services/app/priv/templates/ruby.eex
@@ -55,7 +55,7 @@ begin
     @execution_result <<
       JSON.dump(
         status: :ok,
-        result: '__code-0__'
+        result: <%= hash_sum %>
       )
   end
 rescue Exception => e

--- a/services/app/priv/templates/ruby.eex
+++ b/services/app/priv/templates/ruby.eex
@@ -1,29 +1,41 @@
 require 'json'
+require 'stringio'
 require 'test/unit'
-$stdout = STDERR
 
 extend Test::Unit::Assertions
+
+original_stdout = $stdout
+$stdout = StringIO.new
+
+@execution_result = []
 
 begin
   require './check/solution'
 
   success = true
 
-  def assert_result(result, expected, error_message, success)
+  def assert_result(result, expected, arguments, success)
     begin
       assert_equal(expected, result)
 
-      puts JSON.dump(
-        status: :success,
-        result: result
-      )
+      @execution_result <<
+        JSON.dump(
+          status: :success,
+          result: result,
+          output: $stdout.string,
+          expected: expected,
+          arguments: arguments
+        )
       success
     rescue Test::Unit::AssertionFailedError
-      puts JSON.dump(
-        status: :failure,
-        result: result,
-        arguments: error_message
-      )
+      @execution_result <<
+        JSON.dump(
+          status: :failure,
+          result: result,
+          output: $stdout.string,
+          expected: expected,
+          arguments: arguments
+        )
       false
     end
   end
@@ -33,15 +45,19 @@ begin
   <% end %>
 
   if success
-    puts JSON.dump(
-      status: :ok,
-      result: <%= hash_sum %>
-    )
+    @execution_result <<
+      JSON.dump(
+        status: :ok,
+        result: '__code-0__'
+      )
   end
 rescue Exception => e
-  puts(JSON.dump(
-         status: :error,
-         result: e.message
-       ))
-  exit(0)
+  @execution_result <<
+    JSON.dump(
+      status: :error,
+      result: e.message
+    )
 end
+
+$stdout = original_stdout
+puts @execution_result

--- a/services/app/priv/templates/ruby.eex
+++ b/services/app/priv/templates/ruby.eex
@@ -14,8 +14,11 @@ begin
 
   success = true
 
-  def assert_result(result, expected, arguments, success)
+  def assert_result(solution, expected, arguments, success)
     begin
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = solution.call(*arguments)
+      finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       assert_equal(expected, result)
 
       @execution_result <<
@@ -23,8 +26,8 @@ begin
           status: :success,
           result: result,
           output: $stdout.string,
-          expected: expected,
-          arguments: arguments
+          arguments: arguments,
+          execution_time: finish - start
         )
       success
     rescue Test::Unit::AssertionFailedError
@@ -35,13 +38,17 @@ begin
           output: $stdout.string,
           expected: expected,
           arguments: arguments
+          arguments: arguments,
+          execution_time: finish - start
+        )
+      success
         )
       false
     end
   end
 
   <%= for %{arguments: arguments, expected: expected} <- checks do %>
-    success = assert_result(method(:solution).call(<%= arguments %>), <%= expected %>, [<%= arguments %>], success)
+    success = assert_result(method(:solution), <%= expected %>, [<%= arguments %>], success)
   <% end %>
 
   if success


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #632

TODO:
- [x] js
- [x] ruby
- [ ] clojure
- [ ] cpp
- [ ] elixir
- [ ] golang
- [ ] haskell
- [ ] js
- [ ] php
- [x] python
- [ ] ts
- [ ] обновить вывод запущенной проверки на клиенте
