### PR TITLE
[#311] Add config params to component ReactMarkdown for corent parsing [

### DIFF
--- a/services/app/assets/js/widgets/components/Task.jsx
+++ b/services/app/assets/js/widgets/components/Task.jsx
@@ -67,7 +67,17 @@ const Task = ({
         </div>
         <div className="d-flex align-items-stretch flex-column">
           <div className="card-text mb-0  h-100  overflow-auto">
-            <ReactMarkdown source={task.description} />
+            <ReactMarkdown
+              source={task.description}
+              renderers={{
+                linkReference: (reference) => {
+                  if (!reference.href) {
+                    return <React.Fragment>[{reference.children}]</React.Fragment>;
+                  }
+                  return <a href={reference.$ref}>{reference.children}</a>
+                }
+              }}
+            />
           </div>
         </div>
         <ContributorsList name={task.name} />

--- a/services/app/assets/js/widgets/components/Task.jsx
+++ b/services/app/assets/js/widgets/components/Task.jsx
@@ -70,12 +70,18 @@ const Task = ({
             <ReactMarkdown
               source={task.description}
               renderers={{
-                linkReference: (reference) => {
+                linkReference: reference => {
                   if (!reference.href) {
-                    return <React.Fragment>[{reference.children}]</React.Fragment>;
+                    return (
+                      <>
+                        [
+                        {reference.children}
+                        ]
+                      </>
+);
                   }
-                  return <a href={reference.$ref}>{reference.children}</a>
-                }
+                  return <a href={reference.$ref}>{reference.children}</a>;
+                },
               }}
             />
           </div>


### PR DESCRIPTION
Ошибка в парсинге квадратных скобок возникала из-за того что react markdown использует для парсинга пакет remark-parse.
В обсуждении данной проблемы на гите react markdown предлагалось добавить функцию обработчик для ссылок.

После добавления функции обработчика, квадратные скобки [] и ссылки <a> отображаются корректно.