### PR TITLE
delete button backToTournament from tournament game

### DIFF
--- a/services/app/assets/js/widgets/containers/Notifications.jsx
+++ b/services/app/assets/js/widgets/containers/Notifications.jsx
@@ -27,7 +27,7 @@ const Notifications = () => {
           </>
       )}
       { isTournamentGame && <BackToTournamentButton /> }
-      <BackToHomeButton />
+      { !isTournamentGame && <BackToHomeButton />}
     </>
 );
 };


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #num
