### PR TITLE
[#781] Rewrited editor toolbar to one component

### DIFF
--- a/services/app/assets/js/widgets/components/GameResultIcon.jsx
+++ b/services/app/assets/js/widgets/components/GameResultIcon.jsx
@@ -8,7 +8,7 @@ const GameResultIcon = ({ resultUser1, resultUser2, className }) => {
     return (
       <OverlayTrigger
         overlay={<Tooltip id={tooltipId}>Player gave up</Tooltip>}
-        placement="left"
+        placement="top"
       >
         <div className={className}>
           <i className="far fa-flag fa-lg align-middle" aria-hidden="true" />
@@ -21,7 +21,7 @@ const GameResultIcon = ({ resultUser1, resultUser2, className }) => {
     return (
       <OverlayTrigger
         overlay={<Tooltip id={tooltipId}>Player won</Tooltip>}
-        placement="left"
+        placement="top"
       >
         <div className={className}>
           <i className="fa fa-trophy fa-lg text-warning align-middle" aria-hidden="true" />

--- a/services/app/assets/js/widgets/components/LanguagePicker.jsx
+++ b/services/app/assets/js/widgets/components/LanguagePicker.jsx
@@ -18,12 +18,15 @@ const LangTitle = ({ slug, name, version }) => (
 const LanguagePicker = ({
   languages, currentLangSlug, onChangeLang, disabled,
 }) => {
-  const customStyle = {
-    menu: provided => ({
-      ...provided,
-      maxWidth: '220px',
-      marginLeft: 0,
-      paddingLeft: '0.5rem',
+  const selectStyles = {
+    control: style => ({ ...style, minWidth: '200px' }),
+    // container: style => ({ ...style, margin: '0.5rem' }),
+    menu: style => ({
+      ...style,
+      maxWidth: '200px',
+      // margin: '1rem',
+      padding: '0.5rem',
+      boxShadow: 'inset 0 1px 0 rgba(0, 0, 0, 0.1)',
     }),
   };
   const langs = languages || defaultLanguages;
@@ -47,8 +50,7 @@ const LanguagePicker = ({
   return (
     <>
       <Select
-        styles={customStyle}
-        className="col-12 col-xl-7"
+        styles={selectStyles}
         defaultValue={defaultLang}
         onChange={changeLang}
         options={options}

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/DarkModeButton.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/DarkModeButton.jsx
@@ -1,0 +1,31 @@
+import { useDispatch } from 'react-redux';
+import React, { useContext } from 'react';
+import cn from 'classnames';
+
+import { DarkModeContext } from '../../contexts/EditorToolbarContext';
+import { actions } from '../../slices';
+import EditorThemes from '../../config/editorThemes';
+
+export default () => {
+  const dispatch = useDispatch();
+
+  const [isDarkMode, toggleDarkMode] = useContext(DarkModeContext);
+
+  const mode = isDarkMode ? EditorThemes.light : EditorThemes.dark;
+
+  const classNames = cn('btn btn-sm border rounded ml-2', {
+    'btn-light': isDarkMode,
+    'btn-secondary': !isDarkMode,
+  });
+
+  const handleToggleDarkMode = () => {
+    toggleDarkMode(!isDarkMode);
+    dispatch(actions.switchEditorsTheme(mode));
+  };
+
+  return (
+    <button type="button" className={classNames} onClick={handleToggleDarkMode}>
+      {isDarkMode ? 'Light' : 'Dark'}
+    </button>
+  );
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/EditorHeightButtons.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/EditorHeightButtons.jsx
@@ -15,8 +15,9 @@ const EditorHeightButtons = ({ typeEditor }) => {
   const compressEditor = userId => () => dispatch(compressEditorHeight(userId));
   const expandEditor = userId => () => dispatch(expandEditorHeight(userId));
   const editorClassNames = cn('btn-group btn-group-sm', {
-    'ml-2': typeEditor === 'left',
-    'mr-2': typeEditor === 'right',
+    // 'ml-2': typeEditor === 'left',
+    // 'mr-2': typeEditor === 'right',
+    'm-1': true,
   });
 
   return (

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
@@ -1,0 +1,77 @@
+import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import cn from 'classnames';
+
+import { EditorToolbarProvider } from '../../contexts/EditorToolbarContext';
+import { changeCurrentLangAndSetTemplate } from '../../middlewares/Game';
+import DarkModeButton from './DarkModeButton';
+import EditorHeightButtons from './EditorHeightButtons';
+import GameResultIcon from '../../components/GameResultIcon';
+import LanguagePicker from '../../components/LanguagePicker';
+import OnlineIndicator from './OnlineIndicator';
+import TypingIcon from './TypingIcon';
+import UserName from '../../components/User/UserName';
+import VimModeButton from './VimModeButton';
+import * as selectors from '../../selectors';
+
+export default props => {
+  const {
+ rightEditor, leftEditor, rightUser, leftUser, resultLeftUser, resultRightUser, side, isStoredGame, isPlayer,
+} = props;
+
+  const dispatch = useDispatch();
+
+  const languages = useSelector(state => selectors.editorLangsSelector(state));
+  const setLang = langSlug => {
+    dispatch(changeCurrentLangAndSetTemplate(langSlug));
+  };
+  const isLeftSide = side === 'left';
+
+  const isSpectator = isStoredGame || !isPlayer;
+  const isDisabled = !isLeftSide || isSpectator;
+
+  const player = isLeftSide ? leftUser : rightUser;
+  const editor = isLeftSide ? leftEditor : rightEditor;
+  const resultLeftPlayer = isLeftSide ? resultLeftUser : resultRightUser;
+  const resultRightPlayer = isLeftSide ? resultRightUser : resultLeftUser;
+  const slug = isLeftSide ? leftEditor.currentLangSlug : rightEditor.currentLangSlug;
+
+  if (!slug) {
+    return null;
+  }
+
+  const userInfoClassNames = cn('btn-group align-items-center justify-content-end m-1', {
+    'flex-row-reverse': !isLeftSide,
+  });
+
+  const editorSettingClassNames = cn('btn-group align-items-center m-1', {
+    'flex-row-reverse': !isLeftSide,
+    'justify-content-end': !isLeftSide,
+  });
+
+  const toolbarClassNames = cn('btn-toolbar justify-content-between align-items-center m-1', {
+    'flex-row-reverse': !isLeftSide,
+  });
+
+  return (
+    <div className={toolbarClassNames} role="toolbar">
+      <div className={editorSettingClassNames} role="group" aria-label="Editor settings">
+        <EditorHeightButtons typeEditor={side} />
+        <LanguagePicker languages={languages} currentLangSlug={slug} onChangeLang={setLang} disabled={isDisabled} />
+        {!isDisabled && (
+          <EditorToolbarProvider>
+            <VimModeButton />
+            <DarkModeButton />
+          </EditorToolbarProvider>
+        )}
+      </div>
+
+      <div className={userInfoClassNames} role="group" aria-label="User info">
+        {isDisabled && <TypingIcon editor={editor} />}
+        <UserName user={player} />
+        <OnlineIndicator player={player || {}} />
+        <GameResultIcon className="mx-2" resultUser1={resultLeftPlayer} resultUser2={resultRightPlayer} />
+      </div>
+    </div>
+  );
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/OnlineIndicator.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/OnlineIndicator.jsx
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+import React from 'react';
+import _ from 'lodash';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { chatUsersSelector } from '../../selectors';
+
+export default ({ player }) => {
+  const onlineUsers = useSelector(state => chatUsersSelector(state));
+  const isOnline = _.find(onlineUsers, { id: player.id });
+
+  const icon = isOnline ? 'user' : 'user-slash';
+  const color = isOnline ? 'green' : 'red';
+
+  return <FontAwesomeIcon icon={icon} className="mx-2" color={color} />;
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/VimModeButton.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/VimModeButton.jsx
@@ -1,0 +1,31 @@
+import { useDispatch } from 'react-redux';
+import React, { useContext } from 'react';
+import cn from 'classnames';
+
+import { VimModeContext } from '../../contexts/EditorToolbarContext';
+import { actions } from '../../slices';
+import EditorModes from '../../config/editorModes';
+
+export default () => {
+  const dispatch = useDispatch();
+
+  const [isVimMode, setVimMode] = useContext(VimModeContext);
+
+  const mode = isVimMode ? EditorModes.default : EditorModes.vim;
+
+  const classNames = cn('btn btn-sm border rounded ml-2', {
+    'btn-light': !isVimMode,
+    'btn-secondary': isVimMode,
+  });
+
+  const handleToggleVimMode = () => {
+    setVimMode(!isVimMode);
+    dispatch(actions.setEditorsMode(mode));
+  };
+
+  return (
+    <button type="button" className={classNames} onClick={handleToggleVimMode}>
+      Vim
+    </button>
+  );
+};

--- a/services/app/assets/js/widgets/containers/GameWidget.jsx
+++ b/services/app/assets/js/widgets/containers/GameWidget.jsx
@@ -3,14 +3,15 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import * as selectors from '../selectors';
 import Editor from './Editor';
-import LeftEditorToolbar from './EditorsToolbars/LeftEditorToolbar';
-import RightEditorToolbar from './EditorsToolbars/RightEditorToolbar';
+import EditorToolbar from './EditorsToolbars/EditorToolbar';
 import GameActionButtons from '../components/GameActionButtons';
 import * as GameActions from '../middlewares/Game';
 import ExecutionOutput from '../components/ExecutionOutput/ExecutionOutput';
 import NotificationsHandler from './NotificationsHandler';
 import editorModes from '../config/editorModes';
 import GameStatusCodes from '../config/gameStatusCodes';
+// import RightEditorToolbar from './EditorsToolbars/RightEditorToolbar';
+// import LeftEditorToolbar from './EditorsToolbars/LeftEditorToolbar';
 
 class GameWidget extends Component {
   static defaultProps = {
@@ -53,6 +54,28 @@ class GameWidget extends Component {
     };
   };
 
+  getToolbarParams = () => {
+    const {
+ leftEditor, rightEditor, currentUserId, leftUserId, rightUserId, players, isStoredGame,
+} = this.props;
+    const rightUser = players[rightUserId];
+    const leftUser = players[leftUserId];
+    const resultLeftUser = _.get(players, [leftUserId, 'gameResult']);
+    const resultRightUser = _.get(players, [rightUserId, 'gameResult']);
+    const isPlayer = _.hasIn(players, currentUserId);
+
+    return {
+      leftEditor,
+      rightEditor,
+      leftUser,
+      rightUser,
+      resultLeftUser,
+      resultRightUser,
+      isStoredGame,
+      isPlayer,
+    };
+  };
+
   getRightEditorParams = () => {
     const { rightEditor, rightEditorHeight } = this.props;
     const editorState = rightEditor;
@@ -87,7 +110,7 @@ class GameWidget extends Component {
       <>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden">
-            <LeftEditorToolbar />
+            <EditorToolbar {...this.getToolbarParams()} side="left" />
             <Editor {...this.getLeftEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(leftEditor, false)}
@@ -96,7 +119,7 @@ class GameWidget extends Component {
         </div>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden">
-            <RightEditorToolbar />
+            <EditorToolbar {...this.getToolbarParams()} side="right" />
             <Editor {...this.getRightEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(rightEditor, true)}
@@ -120,6 +143,8 @@ const mapStateToProps = state => {
     players: selectors.gamePlayersSelector(state),
     leftEditor,
     rightEditor,
+    leftUserId,
+    rightUserId,
     leftEditorHeight: selectors.editorHeightSelector(leftUserId)(state),
     rightEditorHeight: selectors.editorHeightSelector(rightUserId)(state),
     leftOutput: selectors.leftExecutionOutputSelector(state),

--- a/services/app/assets/js/widgets/contexts/EditorToolbarContext.jsx
+++ b/services/app/assets/js/widgets/contexts/EditorToolbarContext.jsx
@@ -1,0 +1,18 @@
+import React, { createContext, useState } from 'react';
+
+export const VimModeContext = createContext();
+export const DarkModeContext = createContext();
+
+export const EditorToolbarProvider = ({ children }) => {
+  const [isVimMode, toggleVimMode] = useState(false);
+  const [isDarkMode, toggleDarkMode] = useState(true);
+
+  return (
+    <VimModeContext.Provider value={[isVimMode, toggleVimMode]}>
+      <DarkModeContext.Provider value={[isDarkMode, toggleDarkMode]}>
+        {' '}
+        {children}
+      </DarkModeContext.Provider>
+    </VimModeContext.Provider>
+  );
+};


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #781 
Черновой вариант

Toolbar игрока:
![Снимок экрана 2020-11-08 в 17 28 22](https://user-images.githubusercontent.com/60138143/98483650-d009f000-2212-11eb-984e-9be85bef14df.png)
![Снимок экрана 2020-11-08 в 17 27 33](https://user-images.githubusercontent.com/60138143/98483652-d26c4a00-2212-11eb-9c63-3fd8363807d5.png)

Toolbar в реплее и у спектатора:
![Снимок экрана 2020-11-08 в 17 25 04](https://user-images.githubusercontent.com/60138143/98483655-d4cea400-2212-11eb-9884-03863de41b32.png)

