### PR TITLE
[#781] Rewrited editor toolbar to one component

### DIFF
--- a/services/app/assets/js/widgets/components/GameResultIcon.jsx
+++ b/services/app/assets/js/widgets/components/GameResultIcon.jsx
@@ -1,7 +1,17 @@
 import React from 'react';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import _ from 'lodash';
+import * as selectors from '../selectors';
 
-const GameResultIcon = ({ resultUser1, resultUser2, className }) => {
+const GameResultIcon = ({ editor: { userId } }) => {
+  const players = useSelector(selectors.gamePlayersSelector);
+
+  const { id: opponentId } = _.find(players, ({ id }) => id !== userId);
+
+  const resultUser1 = _.get(players, [userId, 'gameResult']);
+  const resultUser2 = _.get(players, [opponentId, 'gameResult']);
+
   const tooltipId = `tooltip-${resultUser1}`;
 
   if (resultUser1 === 'gave_up') {
@@ -10,7 +20,7 @@ const GameResultIcon = ({ resultUser1, resultUser2, className }) => {
         overlay={<Tooltip id={tooltipId}>Player gave up</Tooltip>}
         placement="left"
       >
-        <div className={className}>
+        <div className="mx-1">
           <i className="far fa-flag fa-lg align-middle" aria-hidden="true" />
         </div>
       </OverlayTrigger>
@@ -23,7 +33,7 @@ const GameResultIcon = ({ resultUser1, resultUser2, className }) => {
         overlay={<Tooltip id={tooltipId}>Player won</Tooltip>}
         placement="left"
       >
-        <div className={className}>
+        <div className="mx-1">
           <i className="fa fa-trophy fa-lg text-warning align-middle" aria-hidden="true" />
         </div>
       </OverlayTrigger>

--- a/services/app/assets/js/widgets/components/LanguagePicker.jsx
+++ b/services/app/assets/js/widgets/components/LanguagePicker.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Gon from 'gon';
 import Select from 'react-select';
 import LanguageIcon from './LanguageIcon';
+import * as selectors from '../selectors';
+import { changeCurrentLangAndSetTemplate } from '../middlewares/Game';
 
 const defaultLanguages = Gon.getAsset('langs');
 
@@ -15,24 +18,43 @@ const LangTitle = ({ slug, name, version }) => (
   </div>
 );
 
-const LanguagePicker = ({
-  languages, currentLangSlug, onChangeLang, disabled,
-}) => {
+const LanguagePicker = ({ disabled, editor: { currentLangSlug } }) => {
   const customStyle = {
-    menu: provided => ({
+    control: provided => ({
       ...provided,
-      maxWidth: '220px',
-      marginLeft: 0,
-      paddingLeft: '0.5rem',
-      'z-index': 11000,
+      height: '31px',
+      minHeight: '31px',
+      minWidth: '190px',
+      backgroundColor: 'hsl(0, 0%, 100%)',
+    }),
+    indicatorsContainer: provided => ({
+      ...provided,
+      height: '29px',
+    }),
+    clearIndicator: provided => ({
+      ...provided,
+      padding: '5px',
+    }),
+    dropdownIndicator: provided => ({
+      ...provided,
+      padding: '5px',
+    }),
+    input: provided => ({
+      ...provided,
+      height: '21px',
     }),
   };
+
+  const dispatch = useDispatch();
+
+  const languages = useSelector(state => selectors.editorLangsSelector(state));
+
   const langs = languages || defaultLanguages;
   const [[currentLang], otherLangs] = _.partition(langs, lang => lang.slug === currentLangSlug);
 
   const options = otherLangs.map(lang => ({ label: <LangTitle {...lang} />, value: lang.name }));
   const changeLang = ({ label: { props } }) => {
-    onChangeLang(props.slug);
+    dispatch(changeCurrentLangAndSetTemplate(props.slug));
   };
 
   const defaultLang = { label: <LangTitle {...currentLang} /> };
@@ -49,7 +71,7 @@ const LanguagePicker = ({
     <>
       <Select
         styles={customStyle}
-        className="col-12 col-xl-7 guide-LanguagePicker"
+        className="mx-1 guide-LanguagePicker"
         defaultValue={defaultLang}
         onChange={changeLang}
         options={options}
@@ -59,8 +81,6 @@ const LanguagePicker = ({
 };
 
 LanguagePicker.propTypes = {
-  currentLangSlug: PropTypes.string.isRequired,
-  onChangeLang: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
 };
 

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/DarkModeButton.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/DarkModeButton.jsx
@@ -1,0 +1,31 @@
+import cn from 'classnames';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import EditorThemes from '../../config/editorThemes';
+import { editorsThemeSelector } from '../../selectors';
+import { actions } from '../../slices';
+
+export default ({ player }) => {
+  const dispatch = useDispatch();
+
+  const currentTheme = useSelector(state => editorsThemeSelector(player.id)(state));
+
+  const isDarkMode = currentTheme === EditorThemes.dark;
+
+  const mode = isDarkMode ? EditorThemes.light : EditorThemes.dark;
+
+  const classNames = cn('btn btn-sm border rounded mr-2', {
+    'btn-light': isDarkMode,
+    'btn-secondary': !isDarkMode,
+  });
+
+  const handleToggleDarkMode = () => {
+    dispatch(actions.switchEditorsTheme(mode));
+  };
+
+  return (
+    <button type="button" className={classNames} onClick={handleToggleDarkMode}>
+      {isDarkMode ? 'Light' : 'Dark'}
+    </button>
+  );
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/EditorHeightButtons.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/EditorHeightButtons.jsx
@@ -1,37 +1,25 @@
 import React from 'react';
-import cn from 'classnames';
-import _ from 'lodash';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { compressEditorHeight, expandEditorHeight } from '../../middlewares/Game';
-import * as selectors from '../../selectors';
 
-const editorSelector = {
-  left: state => _.get(selectors.leftEditorSelector(state), ['userId'], null),
-  right: state => _.get(selectors.rightEditorSelector(state), ['userId'], null),
-};
-const EditorHeightButtons = ({ typeEditor }) => {
-  const leftUserId = useSelector(editorSelector[typeEditor]);
+const EditorHeightButtons = ({ editor: { userId } }) => {
   const dispatch = useDispatch();
-  const compressEditor = userId => () => dispatch(compressEditorHeight(userId));
-  const expandEditor = userId => () => dispatch(expandEditorHeight(userId));
-  const editorClassNames = cn('btn-group btn-group-sm', {
-    'ml-2': typeEditor === 'left',
-    'mr-2': typeEditor === 'right',
-  });
+  const compressEditor = userID => () => dispatch(compressEditorHeight(userID));
+  const expandEditor = userID => () => dispatch(expandEditorHeight(userID));
 
   return (
-    <div className={editorClassNames} role="group" aria-label="Editor height">
+    <div className="mx-1" role="group" aria-label="Editor height">
       <button
         type="button"
         className="btn btn-sm btn-light border rounded"
-        onClick={compressEditor(leftUserId)}
+        onClick={compressEditor(userId)}
       >
         <i className="fas fa-compress-arrows-alt" aria-hidden="true" />
       </button>
       <button
         type="button"
         className="btn btn-sm btn-light border rounded ml-2"
-        onClick={expandEditor(leftUserId)}
+        onClick={expandEditor(userId)}
       >
         <i className="fas fa-expand-arrows-alt" aria-hidden="true" />
       </button>

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import cn from 'classnames';
+
+import DarkModeButton from './DarkModeButton';
+import EditorHeightButtons from './EditorHeightButtons';
+import GameResultIcon from '../../components/GameResultIcon';
+import LanguagePicker from '../../components/LanguagePicker';
+import OnlineIndicator from './OnlineIndicator';
+import TypingIcon from './TypingIcon';
+import UserName from '../../components/User/UserName';
+import VimModeButton from './VimModeButton';
+
+export default ({
+ isRightEditor, isSpectator, player, editor,
+}) => {
+  const isReversedClassName = cn({
+    'flex-row-reverse': isRightEditor,
+  });
+
+  const isContentEndClassName = cn('', {
+    'justify-content-end': isRightEditor,
+  });
+
+  return (
+    <div className={`btn-toolbar justify-content-between align-items-center m-1 ${isReversedClassName}`} role="toolbar">
+      <div
+        className={`btn-group align-items-center m-1 ${isReversedClassName} ${isContentEndClassName}`}
+        role="group"
+        aria-label="Editor settings"
+      >
+        <EditorHeightButtons editor={editor} />
+        <LanguagePicker editor={editor} disabled={isSpectator} />
+      </div>
+      {!isSpectator && (
+        <div className="btn-group align-items-center mr-auto" role="group" aria-label="Editor mode">
+          <VimModeButton player={player} />
+          <DarkModeButton player={player} />
+        </div>
+      )}
+      <div className={`btn-group align-items-center justify-content-end m-1 ${isReversedClassName}`} role="group" aria-label="User info">
+        {isSpectator && <TypingIcon editor={editor} />}
+        <UserName user={player} />
+        <OnlineIndicator player={player} />
+        <GameResultIcon editor={editor} />
+      </div>
+    </div>
+  );
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/EditorToolbar.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import cn from 'classnames';
-
 import DarkModeButton from './DarkModeButton';
 import EditorHeightButtons from './EditorHeightButtons';
 import GameResultIcon from '../../components/GameResultIcon';
@@ -11,38 +9,26 @@ import UserName from '../../components/User/UserName';
 import VimModeButton from './VimModeButton';
 
 export default ({
- isRightEditor, isSpectator, player, editor,
-}) => {
-  const isReversedClassName = cn({
-    'flex-row-reverse': isRightEditor,
-  });
-
-  const isContentEndClassName = cn('', {
-    'justify-content-end': isRightEditor,
-  });
-
-  return (
-    <div className={`btn-toolbar justify-content-between align-items-center m-1 ${isReversedClassName}`} role="toolbar">
-      <div
-        className={`btn-group align-items-center m-1 ${isReversedClassName} ${isContentEndClassName}`}
-        role="group"
-        aria-label="Editor settings"
-      >
-        <EditorHeightButtons editor={editor} />
-        <LanguagePicker editor={editor} disabled={isSpectator} />
-      </div>
-      {!isSpectator && (
-        <div className="btn-group align-items-center mr-auto" role="group" aria-label="Editor mode">
-          <VimModeButton player={player} />
-          <DarkModeButton player={player} />
-        </div>
-      )}
-      <div className={`btn-group align-items-center justify-content-end m-1 ${isReversedClassName}`} role="group" aria-label="User info">
-        {isSpectator && <TypingIcon editor={editor} />}
-        <UserName user={player} />
-        <OnlineIndicator player={player} />
-        <GameResultIcon editor={editor} />
-      </div>
+ isSpectator, player, editor, toolbarClassNames, editorSettingClassNames, userInfoClassNames,
+}) => (
+  <div className={toolbarClassNames} role="toolbar">
+    <div className={editorSettingClassNames} role="group" aria-label="Editor settings">
+      <EditorHeightButtons editor={editor} />
+      <LanguagePicker editor={editor} disabled={isSpectator} />
     </div>
+
+    {!isSpectator && (
+    <div className="btn-group align-items-center mr-auto" role="group" aria-label="Editor mode">
+      <VimModeButton player={player} />
+      <DarkModeButton player={player} />
+    </div>
+      )}
+
+    <div className={userInfoClassNames} role="group" aria-label="User info">
+      {isSpectator && <TypingIcon editor={editor} />}
+      <UserName user={player} />
+      <OnlineIndicator player={player} />
+      <GameResultIcon editor={editor} />
+    </div>
+  </div>
   );
-};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/OnlineIndicator.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/OnlineIndicator.jsx
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+import React from 'react';
+import _ from 'lodash';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { chatUsersSelector } from '../../selectors';
+
+export default ({ player }) => {
+  const onlineUsers = useSelector(state => chatUsersSelector(state));
+  const isOnline = _.find(onlineUsers, { id: player.id });
+
+  const icon = isOnline ? 'user' : 'user-slash';
+  const color = isOnline ? 'green' : 'red';
+
+  return <FontAwesomeIcon className="mx-2" icon={icon} color={color} fixedWidth />;
+};

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/TypingIcon.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/TypingIcon.jsx
@@ -2,15 +2,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useEffect, useState } from 'react';
 import cn from 'classnames';
 
-const TypingIcon = ({ editor }) => {
-  const { text } = editor;
+const TypingIcon = ({ editor: { text } }) => {
   const [showTyping, setShowTyping] = useState(true);
 
   useEffect(() => {
     setShowTyping(true);
     setTimeout(() => {
       setShowTyping(false);
-    }, 500);
+    }, 1000);
   }, [text]);
 
   const classNames = cn('text-info mx-3', {

--- a/services/app/assets/js/widgets/containers/EditorsToolbars/VimModeButton.jsx
+++ b/services/app/assets/js/widgets/containers/EditorsToolbars/VimModeButton.jsx
@@ -1,0 +1,30 @@
+import cn from 'classnames';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import EditorModes from '../../config/editorModes';
+import { editorsModeSelector } from '../../selectors';
+import { actions } from '../../slices';
+
+export default ({ player }) => {
+  const dispatch = useDispatch();
+  const currentMode = useSelector(state => editorsModeSelector(player.id)(state));
+
+  const isVimMode = currentMode === EditorModes.vim;
+
+  const mode = isVimMode ? EditorModes.default : EditorModes.vim;
+
+  const classNames = cn('btn btn-sm border rounded mr-2', {
+    'btn-light': !isVimMode,
+    'btn-secondary': isVimMode,
+  });
+
+  const handleToggleVimMode = () => {
+    dispatch(actions.setEditorsMode(mode));
+  };
+
+  return (
+    <button type="button" className={classNames} onClick={handleToggleVimMode}>
+      Vim
+    </button>
+  );
+};

--- a/services/app/assets/js/widgets/containers/GameWidget.jsx
+++ b/services/app/assets/js/widgets/containers/GameWidget.jsx
@@ -87,11 +87,17 @@ class GameWidget extends Component {
       // FIXME: render loader
       return null;
     }
+
     return (
       <>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden" data-guide-id="LeftEditor">
-            <EditorToolbar {...this.getToolbarParams(leftEditor)} />
+            <EditorToolbar
+              {...this.getToolbarParams(leftEditor)}
+              toolbarClassNames="btn-toolbar justify-content-between align-items-center m-1"
+              editorSettingClassNames="btn-group align-items-center m-1"
+              userInfoClassNames="btn-group align-items-center justify-content-end m-1"
+            />
             <Editor {...this.getLeftEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(leftEditor, false)}
@@ -100,7 +106,12 @@ class GameWidget extends Component {
         </div>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden">
-            <EditorToolbar {...this.getToolbarParams(rightEditor)} isRightEditor />
+            <EditorToolbar
+              {...this.getToolbarParams(rightEditor)}
+              toolbarClassNames="btn-toolbar justify-content-between align-items-center m-1 flex-row-reverse"
+              editorSettingClassNames="btn-group align-items-center m-1 flex-row-reverse justify-content-end"
+              userInfoClassNames="btn-group align-items-center justify-content-end m-1 flex-row-reverse"
+            />
             <Editor {...this.getRightEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(rightEditor, true)}

--- a/services/app/assets/js/widgets/containers/GameWidget.jsx
+++ b/services/app/assets/js/widgets/containers/GameWidget.jsx
@@ -3,8 +3,7 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import * as selectors from '../selectors';
 import Editor from './Editor';
-import LeftEditorToolbar from './EditorsToolbars/LeftEditorToolbar';
-import RightEditorToolbar from './EditorsToolbars/RightEditorToolbar';
+import EditorToolbar from './EditorsToolbars/EditorToolbar';
 import GameActionButtons from '../components/GameActionButtons';
 import * as GameActions from '../middlewares/Game';
 import ExecutionOutput from '../components/ExecutionOutput/ExecutionOutput';
@@ -37,8 +36,8 @@ class GameWidget extends Component {
     const editorState = leftEditor;
     const onChange = editable
       ? value => {
-        updateEditorValue(value);
-      }
+          updateEditorValue(value);
+        }
       : _.noop;
 
     return {
@@ -67,18 +66,23 @@ class GameWidget extends Component {
     };
   };
 
-  renderGameActionButtons = (editor, disabled) => (
-    <GameActionButtons disabled={disabled} editorUser={editor.userId} />
-  );
+  renderGameActionButtons = (editor, disabled) => <GameActionButtons disabled={disabled} editorUser={editor.userId} />;
+
+  getToolbarParams = editor => {
+    const { currentUserId, players, isStoredGame } = this.props;
+    const isPlayer = editor.userId === currentUserId;
+
+    return {
+      isSpectator: isStoredGame || !isPlayer,
+      player: players[editor.userId],
+      editor,
+    };
+  };
 
   render() {
     const {
-      isStoredGame,
-      leftEditor,
-      rightEditor,
-      leftOutput,
-      rightOutput,
-    } = this.props;
+ isStoredGame, leftEditor, rightEditor, leftOutput, rightOutput,
+} = this.props;
     if (leftEditor === null || rightEditor === null) {
       // FIXME: render loader
       return null;
@@ -87,7 +91,7 @@ class GameWidget extends Component {
       <>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden" data-guide-id="LeftEditor">
-            <LeftEditorToolbar />
+            <EditorToolbar {...this.getToolbarParams(leftEditor)} />
             <Editor {...this.getLeftEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(leftEditor, false)}
@@ -96,7 +100,7 @@ class GameWidget extends Component {
         </div>
         <div className="col-12 col-md-6 p-1">
           <div className="card overflow-hidden">
-            <RightEditorToolbar />
+            <EditorToolbar {...this.getToolbarParams(rightEditor)} isRightEditor />
             <Editor {...this.getRightEditorParams()} />
             {/* TODO: move state to parent component */}
             {!isStoredGame && this.renderGameActionButtons(rightEditor, true)}
@@ -126,8 +130,7 @@ const mapStateToProps = state => {
     rightOutput: selectors.rightExecutionOutputSelector(state),
     leftEditorsMode: selectors.editorsModeSelector(leftUserId)(state),
     theme: selectors.editorsThemeSelector(leftUserId)(state),
-    isStoredGame:
-      selectors.gameStatusSelector(state).status === GameStatusCodes.stored,
+    isStoredGame: selectors.gameStatusSelector(state).status === GameStatusCodes.stored,
   };
 };
 

--- a/services/app/assets/js/widgets/selectors/index.js
+++ b/services/app/assets/js/widgets/selectors/index.js
@@ -74,6 +74,14 @@ export const rightEditorSelector = state => {
   return editorSelector(state);
 };
 
+export const editorSideSelector = side => state => {
+  const editors = {
+    left: leftEditorSelector,
+    right: rightEditorSelector,
+  };
+  return editors[side](state);
+};
+
 export const currentPlayerTextByLangSelector = lang => state => {
   const userId = currentUserIdSelector(state);
   const editorTexts = editorTextsSelector(state);


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #781

Toolbar игрока:
![ingame](https://user-images.githubusercontent.com/60138143/99313944-08d84380-2869-11eb-9da3-6bacbfb19727.png)

Toolbar в реплее и у спектатора:
![p vs bot](https://user-images.githubusercontent.com/60138143/99313865-f1995600-2868-11eb-8c95-ea5b78933613.png)

Игрок против игрока:
![p vs p](https://user-images.githubusercontent.com/60138143/99314024-260d1200-2869-11eb-9d44-544ba630d4d3.png)
