### PR TITLE
fix default bool for php template

### DIFF
--- a/services/app/lib/codebattle/languages.ex
+++ b/services/app/lib/codebattle/languages.ex
@@ -419,7 +419,7 @@ defmodule Codebattle.Languages do
           "float" => "0.1",
           "string" => "\"value\"",
           "array" => "[<%= value %>]",
-          "boolean" => "False",
+          "boolean" => "false",
           "hash" => "array(\"key\" => <%= value %>)"
         },
         checker_meta: %{


### PR DESCRIPTION
False - невалидное значение, должно быть `false`
