### PR TITLE
Upgrade node.js version to the last LTS version

### DIFF
--- a/services/app/dockers/js/Dockerfile
+++ b/services/app/dockers/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.13.0
+FROM node:14.15.1
 
 RUN apt-get update && apt-get install -y build-essential --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reasons to update: ES2020, current version of node.js doesn't support some function/methods/.etc from ES2020

For example: https://v8.dev/features/nullish-coalescing only in v14 and above

![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #__ISSUE_ID__
