### PR TITLE
fix leaderboard container width[iss-950]

### DIFF
--- a/services/app/assets/js/widgets/containers/LobbyWidget.jsx
+++ b/services/app/assets/js/widgets/containers/LobbyWidget.jsx
@@ -383,7 +383,7 @@ const LobbyWidget = () => {
       {renderModal(show, handleCloseModal)}
       <div className="row">
         {/* {isGuestCurrentUser ? <Intro /> : <StartGamePanel />} */}
-        <div className="col-sm-9 p-0">
+        <div className="col-lg-8 col-md-12 p-0 mb-2 pr-lg-2">
           <GameContainers
             activeGames={activeGames}
             completedGames={completedGames}
@@ -392,7 +392,7 @@ const LobbyWidget = () => {
           />
         </div>
 
-        <div className="d-flex flex-column col-sm-3">
+        <div className="d-flex flex-column col-lg-4 col-md-12 p-0">
           <TopPlayersPerPeriod />
           <div className="mt-2">
             <TopPlayersEver />


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #__ISSUE_ID__

What's done. 
xl-lg:
![image](https://user-images.githubusercontent.com/55243777/107150189-b0977600-696d-11eb-8fe3-ab8afa42e86e.png)

md:
![image](https://user-images.githubusercontent.com/55243777/107150202-c9a02700-696d-11eb-85c3-62973c1337f9.png)
 

