### PR TITLE
username align fix

### DIFF
--- a/services/app/lib/codebattle_web/templates/layout/app.html.slime
+++ b/services/app/lib/codebattle_web/templates/layout/app.html.slime
@@ -56,7 +56,7 @@ html lang="en"
                 li.nav-item.dropdown.d
                   a.nav-link.noborder.d-flex.px-0[href='#' aria-expanded="false" aria-haspopup="true" data-toggle="dropdown"]
                     .d-flex.flex-column.mr-2
-                      h5.text-white.mb-0
+                      h5.text-white.text-right.mb-0
                         = @current_user.name
                       .text-right
                         img[alt="#{@current_user.rating}" src="/assets/images/rating.svg"]


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #968 
Поправил выравнивание имени пользователя на панели навигации.