### PR TITLE
Fix rematch after timeouts: terminate the game after 15 minutes passe…

### DIFF
--- a/services/app/.credo.exs
+++ b/services/app/.credo.exs
@@ -118,9 +118,11 @@
         #
         {Credo.Check.Refactor.CondStatements, []},
         {Credo.Check.Refactor.CyclomaticComplexity, false},
+        {Credo.Check.Refactor.FilterFilter, false},
         {Credo.Check.Refactor.FunctionArity, []},
         {Credo.Check.Refactor.LongQuoteBlocks, false},
         {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MapJoin, false},
         {Credo.Check.Refactor.MatchInCondition, []},
         {Credo.Check.Refactor.NegatedConditionsInUnless, []},
         {Credo.Check.Refactor.NegatedConditionsWithElse, []},

--- a/services/app/config/config.exs
+++ b/services/app/config/config.exs
@@ -101,6 +101,11 @@ config :codebattle, :firebase,
 
 config :codebattle, admins: ["vtm", "ReDBrother"]
 
+config :codebattle, Codebattle.GameProcess,
+  # 1 hour
+  default_timeout: 3600,
+  timeout_seconds_whitelist: [60, 120, 300, 600, 900, 1200, 1800, 3600, 7200]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/services/app/config/test.exs
+++ b/services/app/config/test.exs
@@ -21,6 +21,7 @@ config :codebattle, Codebattle.Repo,
   password: System.get_env("CODEBATTLE_DB_PASSWORD", "postgres"),
   database: "codebattle_test",
   hostname: System.get_env("CODEBATTLE_DB_HOSTNAME", "localhost"),
+  port: System.get_env("CODEBATTLE_DB_PORT", "5432"),
   pool: Ecto.Adapters.SQL.Sandbox,
   ownership_timeout: 99_999_999
 
@@ -28,6 +29,10 @@ config :codebattle, Codebattle.Bot,
   timeout: 60_000,
   timeout_start_playbook: 0,
   min_bot_player_speed: 0
+
+config :codebattle, Codebattle.GameProcess,
+  default_timeout: 3600,
+  timeout_seconds_whitelist: [1, 60, 120, 300, 600, 900, 1200, 1800, 3600, 7200]
 
 adapter =
   case System.get_env("CODEBATTLE_RUN_CODE_CHECK") do

--- a/services/app/lib/codebattle/game_process/engine/standard.ex
+++ b/services/app/lib/codebattle/game_process/engine/standard.ex
@@ -13,9 +13,10 @@ defmodule Codebattle.GameProcess.Engine.Standard do
 
   use Engine.Base
 
-  # 1 hour
-  @default_timeout 3600
-  @timeout_seconds_whitelist [60, 120, 300, 600, 900, 1200, 1800, 3600, 7200]
+  @default_timeout Application.compile_env(:codebattle, Codebattle.GameProcess)[:default_timeout]
+  @timeout_seconds_whitelist Application.compile_env(:codebattle, Codebattle.GameProcess)[
+                               :timeout_seconds_whitelist
+                             ]
 
   @impl Engine.Base
 

--- a/services/app/lib/codebattle/game_process/fsm.ex
+++ b/services/app/lib/codebattle/game_process/fsm.ex
@@ -185,6 +185,15 @@ defmodule Codebattle.GameProcess.Fsm do
   end
 
   defstate timeout do
+    defevent rematch_send_offer(params), data: data do
+      new_data = handle_rematch_offer(data, params)
+      next_state(:timeout, Map.merge(data, new_data))
+    end
+
+    defevent rematch_reject(_params), data: data do
+      next_state(:timeout, %{data | rematch_state: :rejected})
+    end
+
     defevent _ do
       next_state(:timeout)
     end

--- a/services/app/test/codebattle/game_process/play_test.exs
+++ b/services/app/test/codebattle/game_process/play_test.exs
@@ -41,7 +41,7 @@ defmodule Codebattle.GameProcess.PlayTest do
 
   test "timeouts the game", %{user1: _, user2: user2, game_id: game_id} do
     assert {:ok, _fsm} = Play.join_game(game_id, user2)
-    assert :ok = Play.timeout_game(game_id)
+    assert {:terminate_after, 15} = Play.timeout_game(game_id)
     game = Repo.get(Game, game_id)
 
     assert game.state == "timeout"

--- a/services/app/test/codebattle_web/integration/game_cases/rematch_test.exs
+++ b/services/app/test/codebattle_web/integration/game_cases/rematch_test.exs
@@ -92,6 +92,68 @@ defmodule Codebattle.GameCases.RematchTest do
     assert FsmHelpers.get_second_player(fsm).editor_text == editor_text_init
   end
 
+  test "game timed out, first send rematch offer, second user accept rematch", %{
+    conn1: conn1,
+    conn2: conn2,
+    socket1: socket1,
+    socket2: socket2,
+    user1: user1,
+    user2: user2
+  } do
+    # Create game
+    conn =
+      conn1
+      |> get(user_path(conn1, :index))
+      |> post(
+        game_path(conn1, :create,
+          level: "elementary",
+          type: "withRandomPlayer",
+          timeout_seconds: 1
+        )
+      )
+
+    game_id = game_id_from_conn(conn)
+
+    game_topic = "game:" <> to_string(game_id)
+    {:ok, _response, socket1} = subscribe_and_join(socket1, GameChannel, game_topic)
+
+    # Second player join game
+    post(conn2, game_path(conn2, :join, game_id))
+    {:ok, _response, socket2} = subscribe_and_join(socket2, GameChannel, game_topic)
+
+    editor_text_init =
+      "const _ = require(\"lodash\");\nconst R = require(\"rambda\");\n\nconst solution = (a, b) => {\n\treturn 0;\n};\n\nmodule.exports = solution;"
+
+    :timer.sleep(1500)
+
+    {:ok, fsm} = Server.get_fsm(game_id)
+
+    assert fsm.state == :timeout
+
+    :timer.sleep(700)
+    # First player send rematch offer
+    Phoenix.ChannelTest.push(socket1, "rematch:send_offer", %{})
+    :timer.sleep(70)
+    {:ok, fsm} = Server.get_fsm(game_id)
+
+    assert fsm.state == :timeout
+    assert FsmHelpers.get_rematch_state(fsm) == :in_approval
+
+    # Second player accept rematch offer
+    Phoenix.ChannelTest.push(socket2, "rematch:accept_offer", %{})
+    :timer.sleep(70)
+    {:ok, fsm} = Server.get_fsm(game_id + 1)
+
+    assert fsm.state == :playing
+    assert FsmHelpers.get_level(fsm) == "elementary"
+    assert FsmHelpers.get_first_player(fsm).id == user1.id
+    assert FsmHelpers.get_second_player(fsm).id == user2.id
+
+    # Text editor go to init state, after start new game after rematch
+    assert FsmHelpers.get_first_player(fsm).editor_text == editor_text_init
+    assert FsmHelpers.get_second_player(fsm).editor_text == editor_text_init
+  end
+
   test "first user gave up and send rematch offer to the bot", %{
     conn1: conn1,
     socket1: socket1

--- a/services/app/test/codebattle_web/integration/game_cases/timeout_test.exs
+++ b/services/app/test/codebattle_web/integration/game_cases/timeout_test.exs
@@ -51,7 +51,8 @@ defmodule Codebattle.GameCases.TimeoutTest do
 
     Codebattle.GameProcess.Play.timeout_game(game_id)
 
-    assert {:error, :game_terminated} = Server.get_fsm(game_id)
+    {:ok, fsm} = Server.get_fsm(game_id)
+    assert :timeout == fsm.state
     assert %{state: "timeout"} = Codebattle.GameProcess.Play.get_game(game_id)
 
     assert ActiveGames.game_exists?(game_id) == false
@@ -79,7 +80,8 @@ defmodule Codebattle.GameCases.TimeoutTest do
 
     Codebattle.GameProcess.Play.timeout_game(game_id)
 
-    assert {:error, :game_terminated} = Server.get_fsm(game_id)
+    {:ok, fsm} = Server.get_fsm(game_id)
+    assert :timeout == fsm.state
     assert %{state: "timeout"} = Codebattle.GameProcess.Play.get_game(game_id)
 
     conn =


### PR DESCRIPTION
1. Fix rematch after timeouts: terminate the game after 15 minutes passed since the timeout instead of terminating it right away.
2. Move timeouts whitelist to configs.
3. Disable new credo checks: Credo.Check.Refactor.MapJoin, Credo.Check.Refactor.FilterFilter, since they make code less readable. 

![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #__ISSUE_ID__
