### PR TITLE
Fix [#1120]: Fixed numerable for members list of tournament page

### DIFF
--- a/services/app/lib/codebattle_web/templates/tournament/_intended_players.html.slimleex
+++ b/services/app/lib/codebattle_web/templates/tournament/_intended_players.html.slimleex
@@ -2,7 +2,7 @@
 = if !Enum.empty?(@players) do
   = for {player, i} <- players do
     .d-flex.align-items-center.my-3
-      span=i
+      span=i+1
       .ml-4
         = render "_player.html", player: player
       = if can_moderate?(@tournament, @current_user) do


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) 
closes #1120


![28-08-2022-11-43-01-Google Chrome](https://user-images.githubusercontent.com/73124371/187063576-8b6e8d11-1b7a-45a3-9b82-0089a60bcb65.png)

