### PR TITLE
Fix tournament team change

### DIFF
--- a/services/app/lib/codebattle/tournament/base.ex
+++ b/services/app/lib/codebattle/tournament/base.ex
@@ -37,6 +37,7 @@ defmodule Codebattle.Tournament.Base do
         players =
           tournament
           |> get_players
+          |> Enum.filter(fn x -> x.id != player.id end)
           |> Enum.concat([player])
           |> Enum.uniq_by(fn x -> x.id end)
 


### PR DESCRIPTION
Fixes #1085 

Баг был в [services/app/lib/codebattle/tournament/base.ex](https://github.com/hexlet-codebattle/codebattle/blob/master/services/app/lib/codebattle/tournament/base.ex) в строках:
```elixir
players =
  tournament
  |> get_players
  |> Enum.concat([player])
  |> Enum.uniq_by(fn x -> x.id end)
```

После добавления пользователя, который уже участвует в турнире, он потом отфильтровывался `uniq_by` и оставалась запись об игроке со старой командой.
Добавил предварительную фильтрацию, чтобы убрать игрока из списка, если он там есть, а затем переписать актуальными данными.