### PR TITLE
fix [#1132]: Fixed autoscroll to anchor after the page loaded

### DIFF
--- a/services/app/assets/js/widgets/containers/LobbyWidget.jsx
+++ b/services/app/assets/js/widgets/containers/LobbyWidget.jsx
@@ -401,6 +401,7 @@ const GameContainers = ({
   useEffect(() => {
     if (!window.location.hash) {
       tabLinkHandler(hashLinkNames.default)();
+      window.scrollTo({ top: 0 });
     }
   }, []);
 


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) 
closes #1132

При первой загрузке страницы возвращает в начало страницы, для пользователя действие не заметно

![06-09-2022-10-53-28-Google Chrome](https://user-images.githubusercontent.com/73124371/188578605-8dcaf4dc-a727-4cd1-b7f7-475d9f35ba83.png)

