### PR TITLE
Fix background for chat input group

### DIFF
--- a/services/app/assets/js/widgets/components/ChatInput.jsx
+++ b/services/app/assets/js/widgets/components/ChatInput.jsx
@@ -91,7 +91,7 @@ export default function ChatInput() {
       {isPickerVisible && (
         <EmojiPicker handleSelect={handleSelectEmodji} hide={hidePicker} />
       )}
-      <div className="input-group-append">
+      <div className="input-group-append bg-white">
         <button
           type="button"
           className="btn btn-outline-secondary py-0 px-1"


### PR DESCRIPTION
![github-icon](https://avatars0.githubusercontent.com/in/15368?s=40&amp;v=4) closes #__ISSUE_ID__
Chat input group was transparent with the underlying message visible.
<img width="641" alt="image" src="https://user-images.githubusercontent.com/25956359/189978729-4d2e7057-01e7-4692-ad0f-05edf9e1ab4e.png">
