### PR TITLE
Fix unstable lobby test

### DIFF
--- a/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
@@ -236,6 +236,7 @@ describe('test task choice', () => {
     fireEvent.click(createGameButton);
 
     expect(getByText(/Choose task/)).toBeInTheDocument();
+    expect(await findByRole('button', { name: 'task1 name' })).toBeInTheDocument();
 
     fireEvent.click(getByRole('button', { name: 'Create Battle' }));
 
@@ -304,7 +305,7 @@ describe('test task choice', () => {
       task_id: 1,
     };
     expect(mainMiddlewares.createInvite).toHaveBeenCalledWith(paramsWithOpponentAndChosenTask);
-  }, 6000);
+  }, 9000);
 
   test('filter tasks by level', async () => {
     const {


### PR DESCRIPTION
Тест 'choose a task' в лобби-тестах периодически падал без очевидных причин. Мне показалось, что это из-за асинхронной природы компонента TackChoice. Добавил дополнительную проверку, чтобы дождаться, когда TackChoice полностью отрисуется.

Может даже тест 'choose a task' стоит как-то переписать. Его выполнение занимает порядка 9 секунд.