### PR TITLE
[#1458] password blank space validation

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/containers/Registration.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/containers/Registration.jsx
@@ -237,6 +237,7 @@ const SignUp = () => {
         .required('Email required'),
       password: Yup
         .string()
+        .matches(/^\S*$/, 'Can\'t contain empty symbols')
         .min(6, 'Should be from 6 to 16 characters')
         .max(16, 'Should be from 6 to 16 characters')
         .required('Password required'),


### PR DESCRIPTION
 [#1458]
При введении пробелов в  пароль появляется уведомление о недопустимых символах в поле "Password", регистрация не происходит.

![image](https://github.com/hexlet-codebattle/codebattle/assets/118844822/0bceb603-ad04-4c53-9b9d-0961215ec1bf)

