### PR TITLE
Fix maxlength on task ids field

### DIFF
--- a/services/app/apps/codebattle/lib/codebattle_web/templates/task_pack/_form.html.heex
+++ b/services/app/apps/codebattle/lib/codebattle_web/templates/task_pack/_form.html.heex
@@ -27,7 +27,6 @@
   <%= text_input(f, :task_ids,
     value: render_task_ids(f.data),
     class: "form-control form-control-lg",
-    maxlength: "37",
     required: true
   ) %>
   <%= error_tag(f, :task_ids) %>


### PR DESCRIPTION
Убирает ограничение на максимальную длину поля на странице редактирования таск-пака