### PR TITLE
#1126: Алиасы и группировка import/export

### DIFF
--- a/services/app/apps/codebattle/.eslintrc.yml
+++ b/services/app/apps/codebattle/.eslintrc.yml
@@ -20,6 +20,29 @@ rules:
   no-console: 0
   react/prop-types: 0
   import/no-unresolved: 0
+  import/no-extraneous-dependencies:
+    - 2
+    - devDependencies: true
+  import/order:
+  - 2
+  - newlines-between: always
+    alphabetize:
+      order: asc
+      caseInsensitive: true
+    groups:
+      - builtin
+      - external
+      - internal
+      - parent
+      - sibling
+      - index
+    pathGroups:
+      - pattern: react
+        group: builtin
+      - pattern: '@/**'
+        group: internal
+    pathGroupsExcludedImportTypes:
+      - internal
   no-param-reassign: 0
   arrow-parens:
     - 2

--- a/services/app/apps/codebattle/assets/js/__tests__/ContributorsList.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/ContributorsList.test.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
+
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
-
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
-import reducers from '../widgets/slices';
 import ContributorsList from '../widgets/pages/game/ContributorsList';
+import reducers from '../widgets/slices';
 
 jest.mock('gon', () => {
   const gonParams = { local: 'en' };

--- a/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
+
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
 import omit from 'lodash/omit';
-
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
-import * as lobbyMiddlewares from '../widgets/middlewares/Lobby';
 import * as invitesMiddleware from '../widgets/middlewares/Invite';
-import reducers from '../widgets/slices';
+import * as lobbyMiddlewares from '../widgets/middlewares/Lobby';
 import LobbyWidget from '../widgets/pages/lobby';
+import reducers from '../widgets/slices';
+
 import { getTestData, toLocalTime } from './helpers';
 
 Object.defineProperty(window, 'scrollTo', {

--- a/services/app/apps/codebattle/assets/js/__tests__/RatingList.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/RatingList.test.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
-import reducers from '../widgets/slices';
 import RatingList from '../widgets/pages/rating/RatingList';
+import reducers from '../widgets/slices';
 
 jest.mock('@fortawesome/react-fontawesome', () => ({
   FontAwesomeIcon: 'img',

--- a/services/app/apps/codebattle/assets/js/__tests__/Registration.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/Registration.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
 
 import Registration from '../widgets/pages/registration';
+
 import { getTestData } from './helpers';
 
 jest.mock('axios');

--- a/services/app/apps/codebattle/assets/js/__tests__/RootContainer.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/RootContainer.test.jsx
@@ -1,22 +1,21 @@
 import React from 'react';
+
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
+import { Provider } from 'react-redux';
 import { createMachine } from 'xstate';
 
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-import { Provider } from 'react-redux';
-import RootContainer from '../widgets/pages/GameRoomWidget';
-
-import reducers from '../widgets/slices';
-import userTypes from '../widgets/config/userTypes';
-import GameStateCodes from '../widgets/config/gameStateCodes';
 import GameRoomModes from '../widgets/config/gameModes';
-
+import GameStateCodes from '../widgets/config/gameStateCodes';
+import userTypes from '../widgets/config/userTypes';
+import editor from '../widgets/machines/editor';
 import game from '../widgets/machines/game';
 import task from '../widgets/machines/task';
-import editor from '../widgets/machines/editor';
+import RootContainer from '../widgets/pages/GameRoomWidget';
+import reducers from '../widgets/slices';
 
 const createPlayer = params => ({
   is_admin: false,

--- a/services/app/apps/codebattle/assets/js/__tests__/UserSettings.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/UserSettings.test.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
+
 import '@testing-library/jest-dom/extend-expect';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-import { Provider } from 'react-redux';
 import axios from 'axios';
+import { Provider } from 'react-redux';
 
-import reducers from '../widgets/slices';
+import languages from '../widgets/config/languages';
 import UserSettings from '../widgets/pages/settings';
 import UserSettingsForm from '../widgets/pages/settings/UserSettingsForm';
-import languages from '../widgets/config/languages';
+import reducers from '../widgets/slices';
 
 jest.mock('@fortawesome/react-fontawesome', () => ({
   FontAwesomeIcon: 'img',

--- a/services/app/apps/codebattle/assets/js/__tests__/WaitingOpponentInfo.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/WaitingOpponentInfo.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';

--- a/services/app/apps/codebattle/assets/js/__tests__/helpers/index.js
+++ b/services/app/apps/codebattle/assets/js/__tests__/helpers/index.js
@@ -1,6 +1,7 @@
-import { URL } from 'url';
 import fs from 'fs';
 import path from 'path';
+import { URL } from 'url';
+
 import moment from 'moment';
 
 const getFixturePath = filename => path.join('..', '..', '__fixtures__', filename);

--- a/services/app/apps/codebattle/assets/js/app.js
+++ b/services/app/apps/codebattle/assets/js/app.js
@@ -20,10 +20,10 @@ import 'phoenix_html';
 import '@fortawesome/fontawesome-free/js/all';
 import 'bootstrap';
 
+import { inspect } from '@xstate/inspect';
 import NProgress from 'nprogress';
 import { Socket } from 'phoenix';
 import { LiveSocket } from 'phoenix_live_view';
-import { inspect } from '@xstate/inspect';
 
 // Import local files
 //

--- a/services/app/apps/codebattle/assets/js/i18n/index.js
+++ b/services/app/apps/codebattle/assets/js/i18n/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
-import i18next from 'i18next';
 import Gon from 'gon';
+import i18next from 'i18next';
 
 const lng = (Gon.getAsset('locale') || navigator.language || navigator.userLanguage).slice(0, 2);
 

--- a/services/app/apps/codebattle/assets/js/socket.js
+++ b/services/app/apps/codebattle/assets/js/socket.js
@@ -1,5 +1,5 @@
-import { Socket } from 'phoenix';
 import Gon from 'gon';
+import { Socket } from 'phoenix';
 
 const socket = new Socket('/ws', {
   params: { token: Gon.getAsset('user_token') },

--- a/services/app/apps/codebattle/assets/js/widgets/App.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/App.jsx
@@ -1,18 +1,18 @@
 import React, { Suspense } from 'react';
-import { Provider } from 'react-redux';
-import { persistStore, persistReducer, PERSIST } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
-import { PersistGate } from 'redux-persist/integration/react';
+
 import {
   configureStore,
   combineReducers,
-  getDefaultMiddleware,
 } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { persistStore, persistReducer, PERSIST } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
+import storage from 'redux-persist/lib/storage';
 import rollbarMiddleware from 'rollbar-redux-middleware';
-import rollbar from './lib/rollbar';
-import reducers from './slices';
 
-import machines from './machines';
+import rollbar from '@/lib/rollbar';
+import machines from '@/machines';
+import reducers from '@/slices';
 
 const { game: mainMachine, editor: editorMachine, task: taskMachine } = machines;
 const { gameUI: gameUIReducer, ...otherReducers } = reducers;
@@ -38,14 +38,9 @@ const rollbarRedux = rollbarMiddleware(rollbar);
 // TODO: put initial state from gon
 const store = configureStore({
   reducer: rootReducer,
-  middleware: [
-    rollbarRedux,
-    ...getDefaultMiddleware({
-      serializableCheck: {
-        ignoredActions: ['ERROR', PERSIST],
-      },
-    }),
-  ],
+  middleware: getDefaultMiddleware => getDefaultMiddleware({
+    serializableCheck: { ignoredActions: ['ERROR', PERSIST] },
+  }).concat(rollbarRedux),
 });
 
 const persistor = persistStore(store);

--- a/services/app/apps/codebattle/assets/js/widgets/components/AccordeonBox.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/AccordeonBox.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import Tooltip from 'react-bootstrap/Tooltip';
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
 import uniqueId from 'lodash/uniqueId';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 import i18n from '../../i18n';
 import color from '../config/statusColor';
 

--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatContextMenu.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatContextMenu.jsx
@@ -4,25 +4,26 @@ import React, {
   useMemo,
   memo,
 } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import qs from 'qs';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import qs from 'qs';
 import {
   Menu,
   Item,
   Separator,
 } from 'react-contexify';
+import { useSelector, useDispatch } from 'react-redux';
 
+import { pushCommand } from '@/middlewares/Chat';
+import { openDirect } from '@/middlewares/Lobby';
 import {
   currentUserIsAdminSelector,
   currentUserIdSelector,
   lobbyDataSelector,
-} from '../selectors';
-import { pushCommand } from '../middlewares/Chat';
-import { actions } from '../slices';
-import { getLobbyUrl, getUserProfileUrl } from '../utils/urlBuilders';
-import { openDirect } from '../middlewares/Lobby';
+} from '@/selectors';
+import { actions } from '@/slices';
+import { getLobbyUrl, getUserProfileUrl } from '@/utils/urlBuilders';
 
 const blackSwordSrc = '/assets/images/fight-black.png';
 const whiteSwordSrc = '/assets/images/fight-white.png';

--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatHeader.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatHeader.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+
 import { useSelector } from 'react-redux';
 
-import Rooms from './Rooms';
-
-import * as selectors from '../selectors';
 import { pushCommand, pushCommandTypes } from '../middlewares/Chat';
+import * as selectors from '../selectors';
+
+import Rooms from './Rooms';
 
 export default function ChatHeader({ showRooms = false, disabled = false }) {
   const currentUserIsAdmin = useSelector(selectors.currentUserIsAdminSelector);

--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import * as _ from 'lodash';
-import { SearchIndex, init } from 'emoji-mart';
+
 import data from '@emoji-mart/data';
+import { SearchIndex, init } from 'emoji-mart';
+import isEmpty from 'lodash/isEmpty';
 import { useSelector } from 'react-redux';
 
+import messageTypes from '../config/messageTypes';
+import { addMessage } from '../middlewares/Chat';
 import * as selectors from '../selectors';
 import useClickAway from '../utils/useClickAway';
-import { addMessage } from '../middlewares/Chat';
+
 import EmojiPicker from './EmojiPicker';
 import EmojiToolTip from './EmojiTooltip';
-import messageTypes from '../config/messageTypes';
 
 const trimColons = message => message.slice(0, message.lastIndexOf(':'));
 
@@ -19,7 +21,7 @@ const getTooltipVisibility = async msg => {
   const endsWithEmojiCodeRegex = /.*:[a-zA-Z]{0,}([^ ])+$/;
   if (!endsWithEmojiCodeRegex.test(msg)) return Promise.resolve(false);
   const colons = getColons(msg);
-  return !_.isEmpty(await SearchIndex.search(colons));
+  return !isEmpty(await SearchIndex.search(colons));
 };
 
 export default function ChatInput({ inputRef, disabled = false }) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/CopyButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/CopyButton.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
-import i18n from 'i18next';
+
 import copy from 'copy-to-clipboard';
+import i18n from 'i18next';
 
 function CopyButton({ className, value, disabled = false }) {
   const [copied, setCopied] = useState(false);

--- a/services/app/apps/codebattle/assets/js/widgets/components/CountdownTimer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/CountdownTimer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import moment from 'moment';
+
 import cn from 'classnames';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 
 const getProgress = (a, b) => (

--- a/services/app/apps/codebattle/assets/js/widgets/components/DropdownMenuDefault.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/DropdownMenuDefault.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import i18n from '../../i18n';
 import levelToClass from '../config/levelToClass';
 

--- a/services/app/apps/codebattle/assets/js/widgets/components/Editor.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Editor.jsx
@@ -1,21 +1,23 @@
 /* eslint-disable no-bitwise */
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import MonacoEditor from 'react-monaco-editor';
+
 import cn from 'classnames';
 import { registerRulesForLanguage } from 'monaco-ace-tokenizer';
 import { initVimMode } from 'monaco-vim';
+import PropTypes from 'prop-types';
+import MonacoEditor from 'react-monaco-editor';
 import { connect } from 'react-redux';
 
-import { gameModeSelector } from '../selectors/index';
-import languages from '../config/languages';
+import editorThemes from '../config/editorThemes';
+import editorUserTypes from '../config/editorUserTypes';
 import GameRoomModes from '../config/gameModes';
+import languages from '../config/languages';
 import sound from '../lib/sound';
+import { addCursorListeners } from '../middlewares/Game';
+import { gameModeSelector } from '../selectors/index';
 import { actions } from '../slices';
 import getLanguageTabSize, { shouldReplaceTabsWithSpaces } from '../utils/editor';
-import editorThemes from '../config/editorThemes';
-import { addCursorListeners } from '../middlewares/Game';
-import editorUserTypes from '../config/editorUserTypes';
+
 import Loading from './Loading';
 
 class Editor extends PureComponent {

--- a/services/app/apps/codebattle/assets/js/widgets/components/EmojiPicker.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/EmojiPicker.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import Picker from '@emoji-mart/react';
+
 import data from '@emoji-mart/data';
+import Picker from '@emoji-mart/react';
+
 import useKey from '../utils/useKey';
 
 export default function EmojiPicker({ handleSelect, hide, disabled = false }) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/EmojiTooltip.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/EmojiTooltip.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
+
 import { SearchIndex } from 'emoji-mart';
-import * as _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import useKey from '../utils/useKey';
 
@@ -54,7 +55,7 @@ export default function EmojiTooltip({ colons, handleSelect, hide }) {
       onClick={() => { handleSelect(emojis[activeIndex]); }}
       size="4"
     >
-      {!_.isEmpty(emojis) && emojis.map((emoji, i) => (
+      {!isEmpty(emojis) && emojis.map((emoji, i) => (
         <option
           key={emoji.id}
           value={+i}

--- a/services/app/apps/codebattle/assets/js/widgets/components/ExtensionPopup.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ExtensionPopup.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { createRoot } from 'react-dom';
+
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
+import { createRoot } from 'react-dom';
 
 const isExtensionInstalled = info => new Promise(resolve => {
   const img = new Image();

--- a/services/app/apps/codebattle/assets/js/widgets/components/FeedbackAlertNotification.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/FeedbackAlertNotification.jsx
@@ -1,11 +1,12 @@
 import React, { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+
 import isEmpty from 'lodash/isEmpty';
 import Alert from 'react-bootstrap/Alert';
-import i18n from '../../i18n';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { actions } from '../slices';
+import i18n from '../../i18n';
 import { gameAlertsSelector } from '../selectors/index';
+import { actions } from '../slices';
 
 const getNotification = status => {
   switch (status) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/FeedbackWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/FeedbackWidget.jsx
@@ -1,10 +1,11 @@
 import React, { useCallback, memo } from 'react';
-import SlackFeedback, { themes } from 'react-slack-feedback';
-import { useDispatch, useSelector } from 'react-redux';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { actions } from '../slices';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useDispatch, useSelector } from 'react-redux';
+import SlackFeedback, { themes } from 'react-slack-feedback';
+
 import { currentUserNameSelector } from '../selectors/index';
+import { actions } from '../slices';
 
 const sendToServer = (payload, success, error) => fetch('/api/v1/feedback', {
   method: 'POST',

--- a/services/app/apps/codebattle/assets/js/widgets/components/GamesHeatmap.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/GamesHeatmap.jsx
@@ -1,9 +1,11 @@
-import { useDispatch } from 'react-redux';
-import CalendarHeatmap from 'react-calendar-heatmap';
 import React, { useState, useEffect } from 'react';
+
 import axios from 'axios';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import { useDispatch } from 'react-redux';
 
 import { actions } from '../slices';
+
 import Loading from './Loading';
 
 function GamesHeatmap() {

--- a/services/app/apps/codebattle/assets/js/widgets/components/InvitesContainer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/InvitesContainer.jsx
@@ -1,14 +1,12 @@
 import React, { useEffect } from 'react';
-import Popover from 'react-bootstrap/Popover';
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import Button from 'react-bootstrap/Button';
-import { useDispatch, useSelector } from 'react-redux';
-import Gon from 'gon';
-import cn from 'classnames';
 
-import GameLevelBadge from './GameLevelBadge';
-import * as selectors from '../selectors';
-import { selectors as invitesSelectors } from '../slices/invites';
+import cn from 'classnames';
+import Gon from 'gon';
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+import { useDispatch, useSelector } from 'react-redux';
+
 import {
   initInvites,
   acceptInvite,
@@ -16,7 +14,11 @@ import {
   cancelInvite,
 } from '../middlewares/Invite';
 import initPresence from '../middlewares/Main';
+import * as selectors from '../selectors';
+import { selectors as invitesSelectors } from '../slices/invites';
 import isSafari from '../utils/browser';
+
+import GameLevelBadge from './GameLevelBadge';
 
 const NoInvites = () => <div className="p-2">No Invites</div>;
 

--- a/services/app/apps/codebattle/assets/js/widgets/components/LanguageIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/LanguageIcon.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import cn from 'classnames';
+
 import { isMacintosh } from '../utils/browser';
 
 const iconsToClass = {

--- a/services/app/apps/codebattle/assets/js/widgets/components/LanguagePicker.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/LanguagePicker.jsx
@@ -1,10 +1,13 @@
 import React, { useContext } from 'react';
+
 import { useDispatch } from 'react-redux';
-import { sendCurrentLangAndSetTemplate, updateCurrentLangAndSetTemplate } from '../middlewares/Game';
-import RoomContext from './RoomContext';
-import LanguagePickerView from './LanguagePickerView';
+
 import { inTestingRoomSelector, openedReplayerSelector } from '../machines/selectors';
+import { sendCurrentLangAndSetTemplate, updateCurrentLangAndSetTemplate } from '../middlewares/Game';
 import useMachineStateSelector from '../utils/useMachineStateSelector';
+
+import LanguagePickerView from './LanguagePickerView';
+import RoomContext from './RoomContext';
 
 function LanguagePicker({ status, editor: { currentLangSlug } }) {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/components/LanguagePickerView.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/LanguagePickerView.jsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import Select from 'react-select';
-import Gon from 'gon';
 
+import Gon from 'gon';
 import capitalize from 'lodash/capitalize';
 import partition from 'lodash/partition';
+import { useSelector } from 'react-redux';
+import Select from 'react-select';
+
 import * as selectors from '../selectors';
+
 import LanguageIcon from './LanguageIcon';
 
 const defaultLanguages = Gon.getAsset('langs');

--- a/services/app/apps/codebattle/assets/js/widgets/components/Loading.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Loading.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ReactLoading from 'react-loading';
 
 const getSize = ({ small = false, adaptive = false }) => {

--- a/services/app/apps/codebattle/assets/js/widgets/components/Message.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Message.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import moment from 'moment';
+
 import cn from 'classnames';
+import moment from 'moment';
 
 import MessageTag from './MessageTag';
 

--- a/services/app/apps/codebattle/assets/js/widgets/components/MessageTag.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/MessageTag.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+
 import { useSelector } from 'react-redux';
 
-import { activeRoomSelector } from '../selectors';
 import messageTypes from '../config/messageTypes';
+import { activeRoomSelector } from '../selectors';
 import { isGeneralRoom, isPrivateMessage } from '../utils/chat';
 
 function MessageTag({ messageType = messageTypes.general }) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/Messages.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Messages.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useLayoutEffect } from 'react';
+
 import useStayScrolled from '../utils/useStayScrolled';
 
 import Message from './Message';

--- a/services/app/apps/codebattle/assets/js/widgets/components/Modal.js
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Modal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { createPortal } from 'react-dom';
 
 const modalRoot = document.getElementById('modal-root');

--- a/services/app/apps/codebattle/assets/js/widgets/components/PlayerLoading.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/PlayerLoading.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ReactLoading from 'react-loading';
 
 const PlayerLoading = ({ small = false, show = false }) => {

--- a/services/app/apps/codebattle/assets/js/widgets/components/PopoverStickOnHover.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/PopoverStickOnHover.jsx
@@ -1,5 +1,6 @@
 // SEE: https://gist.github.com/lou/571b7c0e7797860d6c555a9fdc0496f9
 import React, { useState, useEffect, useRef } from 'react';
+
 import PropTypes from 'prop-types';
 import Overlay from 'react-bootstrap/Overlay';
 import Popover from 'react-bootstrap/Popover';

--- a/services/app/apps/codebattle/assets/js/widgets/components/ResultIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ResultIcon.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Tooltip from 'react-bootstrap/Tooltip';
+
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 
 const ResultIcon = ({ gameId, player1, player2 }) => {
   const tooltipId = `tooltip-${gameId}-${player1.id}`;

--- a/services/app/apps/codebattle/assets/js/widgets/components/Rooms.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Rooms.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { useDispatch, useSelector } from 'react-redux';

--- a/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
@@ -4,8 +4,9 @@ import React, {
   useEffect,
   useCallback,
 } from 'react';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
 
 const delta = 10;
 

--- a/services/app/apps/codebattle/assets/js/widgets/components/Timer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Timer.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
+
 import useTimer from '../utils/useTimer';
 
 function Timer({ time }) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/TournamentType.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/TournamentType.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function TournamentType({ type }) {

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserAchievements.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserAchievements.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import isEmpty from 'lodash/isEmpty';
 
 const LangIcon = ({ size = 'md', lang }) => {

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { camelizeKeys } from 'humps';
-import cn from 'classnames';
+
 import axios from 'axios';
+import cn from 'classnames';
+import { camelizeKeys } from 'humps';
+import { useDispatch, useSelector } from 'react-redux';
 
 import * as selectors from '../selectors';
 import { actions } from '../slices';
+
+import PopoverStickOnHover from './PopoverStickOnHover';
 import UserName from './UserName';
 import UserStats from './UserStats';
-import PopoverStickOnHover from './PopoverStickOnHover';
 
 function UserPopoverContent({ user }) {
   // TODO: store stats in global redux state

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserName.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserName.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+
 import i18n from '../../i18n';
+
 import LanguageIcon from './LanguageIcon';
 
 const renderUserName = ({ id, name, rank }) => {

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserStats.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserStats.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+
+import LanguageIcon from './LanguageIcon';
 import Loading from './Loading';
 import UserAchievements from './UserAchievements';
-import LanguageIcon from './LanguageIcon';
 
 const UserStats = ({ data, user: userInfo }) => {
   const avatarUrl = userInfo.avatarUrl || data?.user?.avatarUrl || '/assets/images/logo.svg';

--- a/services/app/apps/codebattle/assets/js/widgets/index.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { createRoot } from 'react-dom/client';
+
 import {
  Game, Builder, Lobby, UsersRating, UserPage, SettingsPage, RegistrationPage, Invites, StairwayGamePage, TournamentPage,
 } from './App';

--- a/services/app/apps/codebattle/assets/js/widgets/lib/player.js
+++ b/services/app/apps/codebattle/assets/js/widgets/lib/player.js
@@ -1,6 +1,7 @@
-import Delta from 'quill-delta';
 import find from 'lodash/find';
 import partition from 'lodash/partition';
+import Delta from 'quill-delta';
+
 import PlaybookStatusCodes from '../config/playbookStatusCodes';
 
 const snapshotStep = 400;

--- a/services/app/apps/codebattle/assets/js/widgets/lib/rollbar.js
+++ b/services/app/apps/codebattle/assets/js/widgets/lib/rollbar.js
@@ -1,5 +1,5 @@
-import Rollbar from 'rollbar';
 import Gon from 'gon';
+import Rollbar from 'rollbar';
 
 const isProd = process.env.NODE_ENV === 'production';
 

--- a/services/app/apps/codebattle/assets/js/widgets/lib/sound.js
+++ b/services/app/apps/codebattle/assets/js/widgets/lib/sound.js
@@ -1,9 +1,10 @@
+import Gon from 'gon';
 import { Howl, Howler } from 'howler';
 import isUndefined from 'lodash/isUndefined';
-import Gon from 'gon';
-import standart from '../config/sound/standart';
+
 import cs from '../config/sound/cs';
 import dendy from '../config/sound/dendy';
+import standart from '../config/sound/standart';
 
 const audioPaths = {
   standart: '/assets/audio/audioSprites/standartSpritesAudio.wav',

--- a/services/app/apps/codebattle/assets/js/widgets/machines/editor.js
+++ b/services/app/apps/codebattle/assets/js/widgets/machines/editor.js
@@ -1,10 +1,11 @@
 import { assign } from 'xstate';
-import sound from '../lib/sound';
-import editorUserTypes from '../config/editorUserTypes';
+
 import {
   editorBtnStatuses,
   editorSettingsByUserType,
 } from '../config/editorSettingsByUserType';
+import editorUserTypes from '../config/editorUserTypes';
+import sound from '../lib/sound';
 
 // settings
 // type - user type for viewers current_user/opponent/player (request features) teammate, clanmate, friend

--- a/services/app/apps/codebattle/assets/js/widgets/machines/game.js
+++ b/services/app/apps/codebattle/assets/js/widgets/machines/game.js
@@ -1,7 +1,8 @@
 import { assign, actions } from 'xstate';
+
+import GameStateCodes from '../config/gameStateCodes';
 import speedModes from '../config/speedModes';
 import sound from '../lib/sound';
-import GameStateCodes from '../config/gameStateCodes';
 
 const { send } = actions;
 

--- a/services/app/apps/codebattle/assets/js/widgets/machines/index.js
+++ b/services/app/apps/codebattle/assets/js/widgets/machines/index.js
@@ -1,7 +1,7 @@
 import { Machine } from 'xstate';
 
-import game, { config as gameConfig } from './game';
 import editor, { config as editorConfig } from './editor';
+import game, { config as gameConfig } from './game';
 import task, { config as taskConfig } from './task';
 
 export default {

--- a/services/app/apps/codebattle/assets/js/widgets/machines/task.js
+++ b/services/app/apps/codebattle/assets/js/widgets/machines/task.js
@@ -1,4 +1,5 @@
 import { assign } from 'xstate';
+
 import { taskStateCodes } from '../config/task';
 import { taskTemplatesStates } from '../utils/builder';
 

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/Chat.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/Chat.js
@@ -1,11 +1,11 @@
 import Gon from 'gon';
-import capitalize from 'lodash/capitalize';
 import { camelizeKeys, decamelizeKeys } from 'humps';
+import capitalize from 'lodash/capitalize';
 
 import socket from '../../socket';
 import { actions } from '../slices';
-import getChatName from '../utils/names';
 import { getSystemMessage } from '../utils/chat';
+import getChatName from '../utils/names';
 
 const isRecord = Gon.getAsset('is_record');
 

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/Game.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/Game.js
@@ -1,30 +1,30 @@
-import find from 'lodash/find';
-import debounce from 'lodash/debounce';
 import axios from 'axios';
 import Gon from 'gon';
 import { camelizeKeys, decamelizeKeys } from 'humps';
+import debounce from 'lodash/debounce';
+import find from 'lodash/find';
+
 import socket from '../../socket';
-import * as selectors from '../selectors';
+import GameRoomModes from '../config/gameModes';
+import GameStateCodes from '../config/gameStateCodes';
+import PlaybookStatusCodes from '../config/playbookStatusCodes';
+import { taskStateCodes } from '../config/task';
 import userTypes from '../config/userTypes';
-import { actions, redirectToNewGame } from '../slices';
 import {
   parse, getFinalState, getText, resolveDiffs,
 } from '../lib/player';
-
-import PlaybookStatusCodes from '../config/playbookStatusCodes';
-import GameStateCodes from '../config/gameStateCodes';
-import GameRoomModes from '../config/gameModes';
-import notification from '../utils/notification';
+import * as selectors from '../selectors';
+import { actions, redirectToNewGame } from '../slices';
 import {
  taskTemplatesStates, labelTaskParamsWithIds, MAX_NAME_LENGTH, MIN_NAME_LENGTH,
 } from '../utils/builder';
-import { taskStateCodes } from '../config/task';
 import {
   getGamePlayers,
   getGameStatus,
   getPlayersExecutionData,
   getPlayersText,
 } from '../utils/gameRoom';
+import notification from '../utils/notification';
 
 const defaultLanguages = Gon.getAsset('langs');
 const gameId = Gon.getAsset('game_id');

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/Lobby.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/Lobby.js
@@ -1,11 +1,12 @@
-import { camelizeKeys } from 'humps';
 import Gon from 'gon';
+import { camelizeKeys } from 'humps';
 import some from 'lodash/some';
 
 import socket from '../../socket';
 import { actions } from '../slices';
-import { calculateExpireDate } from './Room';
 import { getSystemMessage } from '../utils/chat';
+
+import { calculateExpireDate } from './Room';
 
 const channelName = 'lobby';
 const isRecord = Gon.getAsset('is_record');

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/Main.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/Main.js
@@ -1,6 +1,6 @@
-import { Presence } from 'phoenix';
 import Gon from 'gon';
 import { camelizeKeys } from 'humps';
+import { Presence } from 'phoenix';
 
 import socket from '../../socket';
 import { actions } from '../slices';

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/StairwayGame.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/StairwayGame.js
@@ -1,7 +1,7 @@
 import { camelizeKeys } from 'humps';
+import find from 'lodash/find';
 import groupBy from 'lodash/groupBy';
 import set from 'lodash/set';
-import find from 'lodash/find';
 
 import socket from '../../socket';
 import { actions } from '../slices';

--- a/services/app/apps/codebattle/assets/js/widgets/middlewares/Users.js
+++ b/services/app/apps/codebattle/assets/js/widgets/middlewares/Users.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { camelizeKeys } from 'humps';
-import qs from 'qs';
 import moment from 'moment';
+import qs from 'qs';
 
 import { actions } from '../slices';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/GameRoomWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/GameRoomWidget.jsx
@@ -1,29 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { connect, useDispatch, useSelector } from 'react-redux';
-import ReactJoyride, { STATUS } from 'react-joyride';
-import { CSSTransition, SwitchTransition } from 'react-transition-group';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import ReactJoyride, { STATUS } from 'react-joyride';
+import { connect, useDispatch, useSelector } from 'react-redux';
+import { CSSTransition, SwitchTransition } from 'react-transition-group';
 
-import sound from '../lib/sound';
-
-import RoomContext from '../components/RoomContext';
-import WaitingOpponentInfo from './game/WaitingOpponentInfo';
-import CodebattlePlayer from './game/CodebattlePlayer';
-import * as GameRoomActions from '../middlewares/Game';
-import * as ChatActions from '../middlewares/Chat';
+import FeedbackAlertNotification from '../components/FeedbackAlertNotification';
 import FeedbackWidget from '../components/FeedbackWidget';
-import TaskConfirmationModal from './builder/TaskConfirmationModal';
-import TaskConfigurationModal from './builder/TaskConfigurationModal';
-import AnimationModal from './game/AnimationModal';
-import NetworkAlert from './game/NetworkAlert';
-
-import GameWidget from './game/GameWidget';
-import InfoWidget from './game/InfoWidget';
-import BuilderSettingsWidget from './builder/BuilderSettingsWidget';
-import BuilderEditorsWidget from './builder/BuilderEditorsWidget';
-
-import useGameRoomMachine from '../utils/useGameRoomMachine';
-import useMachineStateSelector from '../utils/useMachineStateSelector';
+import RoomContext from '../components/RoomContext';
+import GameStateCodes from '../config/gameStateCodes';
+import sound from '../lib/sound';
 import {
   inPreviewRoomSelector,
   inBuilderRoomSelector,
@@ -32,10 +18,23 @@ import {
   gameRoomKeySelector,
   roomStateSelector,
 } from '../machines/selectors';
-import { actions } from '../slices';
+import * as ChatActions from '../middlewares/Chat';
+import * as GameRoomActions from '../middlewares/Game';
 import { gameStatusSelector, isShowGuideSelector } from '../selectors';
-import GameStateCodes from '../config/gameStateCodes';
-import FeedbackAlertNotification from '../components/FeedbackAlertNotification';
+import { actions } from '../slices';
+import useGameRoomMachine from '../utils/useGameRoomMachine';
+import useMachineStateSelector from '../utils/useMachineStateSelector';
+
+import BuilderEditorsWidget from './builder/BuilderEditorsWidget';
+import BuilderSettingsWidget from './builder/BuilderSettingsWidget';
+import TaskConfigurationModal from './builder/TaskConfigurationModal';
+import TaskConfirmationModal from './builder/TaskConfirmationModal';
+import AnimationModal from './game/AnimationModal';
+import CodebattlePlayer from './game/CodebattlePlayer';
+import GameWidget from './game/GameWidget';
+import InfoWidget from './game/InfoWidget';
+import NetworkAlert from './game/NetworkAlert';
+import WaitingOpponentInfo from './game/WaitingOpponentInfo';
 
 const steps = [
   {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/AssertsOutput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/AssertsOutput.jsx
@@ -1,8 +1,10 @@
 import React, { memo } from 'react';
+
 import uniqueId from 'lodash/uniqueId';
+
 import AccordeonBox from '../../components/AccordeonBox';
-import color from '../../config/statusColor';
 import assertsStatuses from '../../config/executionStatuses';
+import color from '../../config/statusColor';
 
 const AssertsOutput = memo(({ asserts, status, output }) => {
   const uniqIndex = uniqueId('assertsOutput');

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BackToTaskBuilderButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BackToTaskBuilderButton.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useCallback } from 'react';
+
 import RoomContext from '../../components/RoomContext';
 
 function BackToTaskBuilderButton() {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderActions.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderActions.jsx
@@ -1,14 +1,10 @@
 import React, { useCallback, useContext } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import * as selectors from '../../selectors';
-import useMachineStateSelector from '../../utils/useMachineStateSelector';
-import {
-  buildTaskAsserts,
-  deleteTask,
-  publishTask,
-  updateTaskState,
-} from '../../middlewares/Game';
+import { useDispatch, useSelector } from 'react-redux';
+
+import RoomContext from '../../components/RoomContext';
+import { taskStateCodes } from '../../config/task';
 import {
   isIdleStateTaskSelector,
   isInvalidStateTaskSelector,
@@ -17,8 +13,14 @@ import {
   isTaskPrepareTestingSelector,
   taskStateSelector,
 } from '../../machines/selectors';
-import { taskStateCodes } from '../../config/task';
-import RoomContext from '../../components/RoomContext';
+import {
+  buildTaskAsserts,
+  deleteTask,
+  publishTask,
+  updateTaskState,
+} from '../../middlewares/Game';
+import * as selectors from '../../selectors';
+import useMachineStateSelector from '../../utils/useMachineStateSelector';
 
 function BuilderActions({ validExamples, clearSuggests }) {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderEditorsWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderEditorsWidget.jsx
@@ -4,33 +4,36 @@ import React, {
   useCallback,
   memo,
 } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import noop from 'lodash/noop';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cn from 'classnames';
-import { actions } from '../../slices';
-import * as selectors from '../../selectors';
-import { reloadGeneratorAndSolutionTemplates } from '../../middlewares/Game';
-import useMachineStateSelector from '../../utils/useMachineStateSelector';
-import {
-  getGeneratorStatus,
-  validationStatuses,
-} from '../../machines/task';
+import noop from 'lodash/noop';
+import { useDispatch, useSelector } from 'react-redux';
+
+import Editor from '../../components/Editor';
+import LanguagePickerView from '../../components/LanguagePickerView';
+import RoomContext from '../../components/RoomContext';
+import { gameRoomEditorStyles } from '../../config/editorSettings';
+import assertsStatuses from '../../config/executionStatuses';
 import {
   isTaskAssertsFormingSelector,
   isTaskAssertsReadySelector,
   taskStateSelector,
 } from '../../machines/selectors';
-import RoomContext from '../../components/RoomContext';
-import Editor from '../../components/Editor';
-import TaskPropStatusIcon from './TaskPropStatusIcon';
+import {
+  getGeneratorStatus,
+  validationStatuses,
+} from '../../machines/task';
+import { reloadGeneratorAndSolutionTemplates } from '../../middlewares/Game';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
+import { taskTemplatesStates } from '../../utils/builder';
+import useMachineStateSelector from '../../utils/useMachineStateSelector';
 import DakModeButton from '../game/DarkModeButton';
 import VimModeButton from '../game/VimModeButton';
-import { gameRoomEditorStyles } from '../../config/editorSettings';
-import { taskTemplatesStates } from '../../utils/builder';
+
 import AssertsOutput from './AssertsOutput';
-import assertsStatuses from '../../config/executionStatuses';
-import LanguagePickerView from '../../components/LanguagePickerView';
+import TaskPropStatusIcon from './TaskPropStatusIcon';
 
 const isGeneratorsError = status => (
   status === assertsStatuses.error

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderExampleForm.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderExampleForm.jsx
@@ -5,17 +5,20 @@ import React, {
   memo,
   useContext,
 } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import cloneDeep from 'lodash/cloneDeep';
+
 import cn from 'classnames';
-import { actions } from '../../slices';
+import cloneDeep from 'lodash/cloneDeep';
+import { useDispatch, useSelector } from 'react-redux';
+
 import RoomContext from '../../components/RoomContext';
-import PreviewAssertsPanel from './PreviewAssertsPanel';
-import OutputSignatureEditPanel from './OutputSignatureEditPanel';
-import InputSignatureEditPanel from './InputSignatureEditPanel';
-import ExamplesEditPanel from './ExamplesEditPanel';
+import { actions } from '../../slices';
 import { MAX_INPUT_ARGUMENTS_COUNT } from '../../utils/builder';
 import useKey from '../../utils/useKey';
+
+import ExamplesEditPanel from './ExamplesEditPanel';
+import InputSignatureEditPanel from './InputSignatureEditPanel';
+import OutputSignatureEditPanel from './OutputSignatureEditPanel';
+import PreviewAssertsPanel from './PreviewAssertsPanel';
 
 const navbarItemClassName = 'nav-item nav-link col-3 border-0 rounded-0 px-1 py-2';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderSettingsWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderSettingsWidget.jsx
@@ -1,11 +1,14 @@
 import React, { memo, useCallback } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
-import BuilderTaskAssignment from './BuilderTaskAssignment';
-import TimerContainer from '../game/TimerContainer';
-import BuilderStatus from './BuilderStatus';
-import BuilderExampleForm from './BuilderExampleForm';
+
 import * as selectors from '../../selectors';
 import { actions } from '../../slices';
+import TimerContainer from '../game/TimerContainer';
+
+import BuilderExampleForm from './BuilderExampleForm';
+import BuilderStatus from './BuilderStatus';
+import BuilderTaskAssignment from './BuilderTaskAssignment';
 
 function BuilderSettingsWidget({ setConfigurationModalShowing }) {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderStatus.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderStatus.jsx
@@ -1,13 +1,16 @@
 import React, { useContext, memo } from 'react';
+
 import { useSelector } from 'react-redux';
+
+import RoomContext from '../../components/RoomContext';
 import { taskStateSelector } from '../../machines/selectors';
-import useMachineStateSelector from '../../utils/useMachineStateSelector';
 import {
   validationStatuses,
   mapStateToValidationStatus,
   getGeneratorStatus,
 } from '../../machines/task';
-import RoomContext from '../../components/RoomContext';
+import useMachineStateSelector from '../../utils/useMachineStateSelector';
+
 import TaskPropStatusIcon from './TaskPropStatusIcon';
 
 function BuilderStatus() {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderTaskAssignment.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/BuilderTaskAssignment.jsx
@@ -1,20 +1,22 @@
 import React, { useCallback } from 'react';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cn from 'classnames';
-import PropTypes from 'prop-types';
+import capitalize from 'lodash/capitalize';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
-import capitalize from 'lodash/capitalize';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
+
 import i18n from '../../../i18n';
-import { actions } from '../../slices';
-import * as selectors from '../../selectors';
 import GameLevelBadge from '../../components/GameLevelBadge';
-import TaskLanguagesSelection from '../game/TaskLanguageSelection';
-import TaskDescriptionMarkdown from '../game/TaskDescriptionMarkdown';
-import { validateTaskName } from '../../middlewares/Game';
 import { taskStateCodes } from '../../config/task';
+import { validateTaskName } from '../../middlewares/Game';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
 import useTaskDescriptionParams from '../../utils/useTaskDescriptionParams';
+import TaskDescriptionMarkdown from '../game/TaskDescriptionMarkdown';
+import TaskLanguagesSelection from '../game/TaskLanguageSelection';
 
 const defaultLevels = ['elementary', 'easy', 'medium', 'hard'].map(level => ({
   value: level,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplePreview.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplePreview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { itemActionClassName, itemClassName } from '../../utils/builder';
 
 const getText = (args, expected) => (

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplesEditPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplesEditPanel.jsx
@@ -1,11 +1,14 @@
 import React, { useCallback } from 'react';
-import cloneDeep from 'lodash/cloneDeep';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+
+import { itemClassName, itemActionClassName } from '../../utils/builder';
+import useValidationExample from '../../utils/useValidationExample';
+
 import ExamplesTrack from './ExamplesTrack';
 import SignatureTrack from './SignatureTrack';
-import useValidationExample from '../../utils/useValidationExample';
-import { itemClassName, itemActionClassName } from '../../utils/builder';
 
 function ExampleForm({
   example,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplesTrack.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/ExamplesTrack.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import isEmpty from 'lodash/isEmpty';
 import cn from 'classnames';
+import isEmpty from 'lodash/isEmpty';
+
 import {
   itemClassName,
   itemActionClassName,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/InputSignatureEditPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/InputSignatureEditPanel.jsx
@@ -2,14 +2,17 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cn from 'classnames';
+
 import {
   argumentTypes,
   defaultSignatureByType,
 } from '../../utils/builder';
-import SignatureTrack from './SignatureTrack';
+
 import SignatureForm from './SignatureForm';
+import SignatureTrack from './SignatureTrack';
 
 function InputSignatureEditPanel({
   items = [],

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/OutputSignatureEditPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/OutputSignatureEditPanel.jsx
@@ -1,13 +1,16 @@
 import React, {
   useCallback,
 } from 'react';
-import isEmpty from 'lodash/isEmpty';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import isEmpty from 'lodash/isEmpty';
+
 import {
   defaultSignatureByType,
   argumentTypes,
   itemActionClassName,
 } from '../../utils/builder';
+
 import SignatureForm from './SignatureForm';
 
 function OutputSignatureEditPanel({

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/PreviewAssertsPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/PreviewAssertsPanel.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
-import cn from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import SignatureTrack from './SignatureTrack';
-import ExamplesTrack from './ExamplesTrack';
-import BuilderActions from './BuilderActions';
-import * as selectors from '../../selectors';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import { useSelector } from 'react-redux';
+
+import { taskStateCodes } from '../../config/task';
+import * as selectors from '../../selectors';
 import {
   itemActionClassName,
   itemClassName,
@@ -14,7 +13,10 @@ import {
   MAX_INPUT_ARGUMENTS_COUNT,
   MIN_EXAMPLES_COUNT,
 } from '../../utils/builder';
-import { taskStateCodes } from '../../config/task';
+
+import BuilderActions from './BuilderActions';
+import ExamplesTrack from './ExamplesTrack';
+import SignatureTrack from './SignatureTrack';
 
 const TaskStateBadge = ({ state }) => {
   const className = cn('badge py-2 mb-2', {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignatureForm.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignatureForm.jsx
@@ -2,8 +2,10 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
-import reverse from 'lodash/reverse';
+
 import isEmpty from 'lodash/isEmpty';
+import reverse from 'lodash/reverse';
+
 import {
   haveNestedType,
   argumentTypes,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignaturePreview.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignaturePreview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { itemActionClassName, itemClassName } from '../../utils/builder';
 
 const getText = (name, type) => (

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignatureTrack.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/SignatureTrack.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import isEmpty from 'lodash/isEmpty';
 import cn from 'classnames';
+import isEmpty from 'lodash/isEmpty';
+
 import {
   itemActionClassName,
   itemAddClassName,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskConfigurationModal.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskConfigurationModal.jsx
@@ -1,12 +1,14 @@
 import React, {
  useState, useCallback, useRef, useEffect, memo,
 } from 'react';
+
+import cn from 'classnames';
 import Modal from 'react-bootstrap/Modal';
 import { useDispatch, useSelector } from 'react-redux';
-import cn from 'classnames';
+
 import { taskStateCodes, taskVisibilityCodes } from '../../config/task';
-import { actions } from '../../slices';
 import { updateTaskVisibility } from '../../middlewares/Game';
+import { actions } from '../../slices';
 
 function TaskConfigurationModal({ modalShowing, setModalShowing }) {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskConfirmationModal.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskConfirmationModal.jsx
@@ -5,15 +5,18 @@ import React, {
   useEffect,
   memo,
 } from 'react';
-import Modal from 'react-bootstrap/Modal';
+
 import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 import { useDispatch, useSelector } from 'react-redux';
+
 import { taskStateCodes } from '../../config/task';
-import { taskTemplatesStates } from '../../utils/builder';
 import { saveTask } from '../../middlewares/Game';
 import { taskParamsSelector } from '../../selectors';
-import SignaturePreview from './SignaturePreview';
+import { taskTemplatesStates } from '../../utils/builder';
+
 import ExamplePreview from './ExamplePreview';
+import SignaturePreview from './SignaturePreview';
 
 const taskSelector = taskParamsSelector();
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskPropStatusIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/builder/TaskPropStatusIcon.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Tooltip from 'react-bootstrap/Tooltip';
+import cn from 'classnames';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 import { validationStatuses } from '../../machines/task';
 import isSafari from '../../utils/browser';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ActionsAfterGame.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ActionsAfterGame.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+
 import { useSelector } from 'react-redux';
+
 import GameRoomModes from '../../config/gameModes';
 import * as selectors from '../../selectors';
-import StartTrainingButton from './StartTrainingButton';
-import SignUpButton from './SignUpButton';
+
 import RematchButton from './RematchButton';
+import SignUpButton from './SignUpButton';
+import StartTrainingButton from './StartTrainingButton';
 
 function ActionsAfterGame() {
   const gameMode = useSelector(selectors.gameModeSelector);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/AnimationModal.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/AnimationModal.jsx
@@ -1,9 +1,11 @@
 import React, { memo } from 'react';
-import Modal from 'react-bootstrap/Modal';
+
 import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 import { useSelector } from 'react-redux';
-import { gamePlayersSelector, currentUserIdSelector } from '../../selectors';
+
 import gifs from '../../config/gifs';
+import { gamePlayersSelector, currentUserIdSelector } from '../../selectors';
 
 function AnimationModal({ setModalShowing, modalShowing }) {
   const players = useSelector(state => gamePlayersSelector(state));

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ApprovePlaybookButtons.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ApprovePlaybookButtons.jsx
@@ -1,5 +1,7 @@
 import React, { useCallback, memo } from 'react';
+
 import { useDispatch } from 'react-redux';
+
 import SolutionTypeCodes from '../../config/solutionTypes';
 import { changePlaybookSolution } from '../../middlewares/Game';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/BackToHomeButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/BackToHomeButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import i18n from '../../../i18n';
 
 export default function BackToHomeButton() {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/BackToTournamentButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/BackToTournamentButton.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { useSelector } from 'react-redux';
+
 import { gameStatusSelector } from '../../selectors';
 
 function BackToTournamentButton() {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ChatWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ChatWidget.jsx
@@ -3,24 +3,27 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
+
+import cn from 'classnames';
 import filter from 'lodash/filter';
 import uniqBy from 'lodash/uniqBy';
-import cn from 'classnames';
 import { useSelector } from 'react-redux';
-import * as selectors from '../../selectors';
-import Messages from '../../components/Messages';
-import UserInfo from '../../components/UserInfo';
-import ChatInput from '../../components/ChatInput';
-import ChatHeader from '../../components/ChatHeader';
-import GameRoomModes from '../../config/gameModes';
-import Notifications from './Notifications';
-import RoomContext from '../../components/RoomContext';
+
 import ChatContextMenu from '../../components/ChatContextMenu';
+import ChatHeader from '../../components/ChatHeader';
+import ChatInput from '../../components/ChatInput';
+import Messages from '../../components/Messages';
+import RoomContext from '../../components/RoomContext';
+import UserInfo from '../../components/UserInfo';
+import GameRoomModes from '../../config/gameModes';
+import { inTestingRoomSelector, openedReplayerSelector } from '../../machines/selectors';
+import * as selectors from '../../selectors';
+import { shouldShowMessage } from '../../utils/chat';
 import useChatContextMenu from '../../utils/useChatContextMenu';
 import useChatRooms from '../../utils/useChatRooms';
-import { shouldShowMessage } from '../../utils/chat';
-import { inTestingRoomSelector, openedReplayerSelector } from '../../machines/selectors';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
+
+import Notifications from './Notifications';
 
 function ChatWidget() {
   const { mainService } = useContext(RoomContext);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/CodebattlePlayer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/CodebattlePlayer.jsx
@@ -1,16 +1,19 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import qs from 'qs';
 import { Slider } from 'react-player-controls';
 import { Direction } from 'react-player-controls/dist/constants';
-import qs from 'qs';
-import CodebattleSliderBar from './CodebattleSliderBar';
-import ControlPanel from './ControlPanel';
+import { connect } from 'react-redux';
+
 import RoomContext from '../../components/RoomContext';
 import speedModes from '../../config/speedModes';
-import { actions } from '../../slices';
-import * as GameActions from '../../middlewares/Game';
 import { replayerMachineStates } from '../../machines/game';
+import * as GameActions from '../../middlewares/Game';
 import { playbookRecordsSelector } from '../../selectors';
+import { actions } from '../../slices';
+
+import CodebattleSliderBar from './CodebattleSliderBar';
+import ControlPanel from './ControlPanel';
 
 const playDelays = {
   [speedModes.normal]: 100,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/CodebattleSliderBar.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/CodebattleSliderBar.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import Tooltip from 'react-bootstrap/Tooltip';
+
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 import { replayerMachineStates } from '../../machines/game';
 
 const handleClassnames = 'cb-slider-handle position-absolute rounded-circle';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ContributorsList.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ContributorsList.jsx
@@ -1,7 +1,8 @@
-import { useDispatch } from 'react-redux';
 import React, { useState, useEffect } from 'react';
-import uniqBy from 'lodash/uniqBy';
+
 import axios from 'axios';
+import uniqBy from 'lodash/uniqBy';
+import { useDispatch } from 'react-redux';
 
 import { actions } from '../../slices';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ControlPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ControlPanel.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
-import { PlayerIcon } from 'react-player-controls';
+
 import cn from 'classnames';
-import Gon from 'gon';
 import copy from 'copy-to-clipboard';
-import { actions } from '../../slices';
+import Gon from 'gon';
+import { PlayerIcon } from 'react-player-controls';
+import { useDispatch } from 'react-redux';
+
 import speedModes from '../../config/speedModes';
 import { replayerMachineStates } from '../../machines/game';
+import { actions } from '../../slices';
 
 const gameId = Gon.getAsset('game_id');
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/DarkModeButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/DarkModeButton.jsx
@@ -1,6 +1,8 @@
-import cn from 'classnames';
 import React from 'react';
+
+import cn from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
+
 import editorThemes from '../../config/editorThemes';
 import { editorsThemeSelector } from '../../selectors';
 import { actions } from '../../slices';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorContainer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorContainer.jsx
@@ -3,22 +3,20 @@ import React, {
   useContext,
   useCallback,
 } from 'react';
-import noop from 'lodash/noop';
-import cn from 'classnames';
-import { useDispatch, useSelector } from 'react-redux';
+
 import { useInterpret } from '@xstate/react';
-import editorModes from '../../config/editorModes';
-import EditorToolbar from './EditorToolbar';
-import * as GameActions from '../../middlewares/Game';
-import { actions } from '../../slices';
-import * as selectors from '../../selectors';
+import cn from 'classnames';
+import noop from 'lodash/noop';
+import { useDispatch, useSelector } from 'react-redux';
+
 import RoomContext from '../../components/RoomContext';
+import editorModes from '../../config/editorModes';
+import { gameRoomEditorStyles } from '../../config/editorSettings';
 import {
   editorBtnStatuses as EditorBtnStatuses,
   editorSettingsByUserType,
 } from '../../config/editorSettingsByUserType';
 import editorUserTypes from '../../config/editorUserTypes';
-import { gameRoomEditorStyles } from '../../config/editorSettings';
 import {
   editorStateSelector,
   inBuilderRoomSelector,
@@ -28,7 +26,12 @@ import {
   isGameOverSelector,
   openedReplayerSelector,
 } from '../../machines/selectors';
+import * as GameActions from '../../middlewares/Game';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
+
+import EditorToolbar from './EditorToolbar';
 
 function EditorContainer({
   id,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorHeightButtons.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorHeightButtons.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { useDispatch } from 'react-redux';
+
 import { compressEditorHeight, expandEditorHeight } from '../../middlewares/Game';
 
 function EditorHeightButtons({ editor: { userId } }) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorToolbar.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorToolbar.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import DarkModeButton from './DarkModeButton';
-import GameResultIcon from './GameResultIcon';
+
 import LanguagePicker from '../../components/LanguagePicker';
 import UserInfo from '../../components/UserInfo';
-import VimModeButton from './VimModeButton';
-import GameActionButtons from './GameActionButtons';
 import GameRoomModes from '../../config/gameModes';
+
+import DarkModeButton from './DarkModeButton';
+import GameActionButtons from './GameActionButtons';
+import GameResultIcon from './GameResultIcon';
 import UserGameScore from './UserGameScore';
+import VimModeButton from './VimModeButton';
 
 const ModeButtons = ({ player }) => (
   <div

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/GameActionButtons.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/GameActionButtons.jsx
@@ -1,13 +1,15 @@
 import React, { useContext, useState } from 'react';
-import { useDispatch } from 'react-redux';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
+import { useDispatch } from 'react-redux';
+
 import RoomContext from '../../components/RoomContext';
+import { inTestingRoomSelector } from '../../machines/selectors';
 import { sendGiveUp, resetTextToTemplateAndSend, resetTextToTemplate } from '../../middlewares/Game';
 import { actions } from '../../slices';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
-import { inTestingRoomSelector } from '../../machines/selectors';
 
 function CheckResultButton({ onClick, status }) {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/GameResult.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/GameResult.jsx
@@ -1,12 +1,14 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import hasIn from 'lodash/hasIn';
+
 import find from 'lodash/find';
+import hasIn from 'lodash/hasIn';
 import Alert from 'react-bootstrap/Alert';
-import * as selectors from '../../selectors';
+import { useSelector } from 'react-redux';
+
+import i18n from '../../../i18n';
 import GameRoomModes from '../../config/gameModes';
 import GameStateCodes from '../../config/gameStateCodes';
-import i18n from '../../../i18n';
+import * as selectors from '../../selectors';
 
 function GameResult() {
   const currentUserId = useSelector(state => selectors.currentUserIdSelector(state));

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/GameResultIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/GameResultIcon.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import Tooltip from 'react-bootstrap/Tooltip';
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import { useSelector } from 'react-redux';
-import get from 'lodash/get';
+
 import find from 'lodash/find';
+import get from 'lodash/get';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import { useSelector } from 'react-redux';
+
 import * as selectors from '../../selectors';
 
 function GameResultIcon({ editor: { userId } }) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/GameWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/GameWidget.jsx
@@ -1,17 +1,20 @@
 import React, { useState, useContext, memo } from 'react';
+
+import cn from 'classnames';
 import get from 'lodash/get';
 import { useSelector } from 'react-redux';
-import cn from 'classnames';
-import RoomContext from '../../components/RoomContext';
-import * as selectors from '../../selectors';
+
 import Editor from '../../components/Editor';
-import EditorContainer from './EditorContainer';
+import RoomContext from '../../components/RoomContext';
 import editorModes from '../../config/editorModes';
-import OutputTab from './OutputTab';
-import Output from './Output';
 import editorUserTypes from '../../config/editorUserTypes';
 import { roomStateSelector } from '../../machines/selectors';
+import * as selectors from '../../selectors';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
+
+import EditorContainer from './EditorContainer';
+import Output from './Output';
+import OutputTab from './OutputTab';
 
 const EditorWrapper = ({ children, id, className }) => (
   <div id={id} className={className}>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/InfoWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/InfoWidget.jsx
@@ -1,5 +1,9 @@
 import React, { useContext, memo } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
+
+import RoomContext from '../../components/RoomContext';
+import { inPreviewRoomSelector, inTestingRoomSelector, roomStateSelector } from '../../machines/selectors';
 import {
   gameTaskSelector,
   gameStatusSelector,
@@ -9,8 +13,7 @@ import {
 } from '../../selectors';
 import { actions } from '../../slices';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
-import { inPreviewRoomSelector, inTestingRoomSelector, roomStateSelector } from '../../machines/selectors';
-import RoomContext from '../../components/RoomContext';
+
 import ChatWidget from './ChatWidget';
 import Output from './Output';
 import OutputTab from './OutputTab';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/NetworkAlert.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/NetworkAlert.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, memo } from 'react';
+
 import RoomContext from '../../components/RoomContext';
 import { isDisconnectedWithMessageSelector } from '../../machines/selectors';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/NewGameButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/NewGameButton.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import qs from 'qs';
 import { connect } from 'react-redux';
+
 import i18n from '../../../i18n';
 import GameTypeCodes from '../../config/gameTypeCodes';
 import * as selectors from '../../selectors';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/Notifications.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/Notifications.jsx
@@ -1,19 +1,22 @@
 import React, { useContext } from 'react';
-import { useSelector } from 'react-redux';
+
 import hasIn from 'lodash/hasIn';
-import ReplayerControlButton from './ReplayerControlButton';
-import ActionsAfterGame from './ActionsAfterGame';
-import GameResult from './GameResult';
-import BackToHomeButton from './BackToHomeButton';
-import GoToNextGame from './GoToNextGame';
-import BackToTournamentButton from './BackToTournamentButton';
-import BackToTaskBuilderButton from '../builder/BackToTaskBuilderButton';
-import * as selectors from '../../selectors';
+import { useSelector } from 'react-redux';
+
 import RoomContext from '../../components/RoomContext';
 import { roomMachineStates, replayerMachineStates } from '../../machines/game';
-import ApprovePlaybookButtons from './ApprovePlaybookButtons';
 import { roomStateSelector } from '../../machines/selectors';
+import * as selectors from '../../selectors';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
+import BackToTaskBuilderButton from '../builder/BackToTaskBuilderButton';
+
+import ActionsAfterGame from './ActionsAfterGame';
+import ApprovePlaybookButtons from './ApprovePlaybookButtons';
+import BackToHomeButton from './BackToHomeButton';
+import BackToTournamentButton from './BackToTournamentButton';
+import GameResult from './GameResult';
+import GoToNextGame from './GoToNextGame';
+import ReplayerControlButton from './ReplayerControlButton';
 
 function Notifications() {
   const { mainService } = useContext(RoomContext);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/Output.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/Output.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import uniqueId from 'lodash/uniqueId';
+
 import { camelizeKeys } from 'humps';
+import uniqueId from 'lodash/uniqueId';
+
 import AccordeonBox from '../../components/AccordeonBox';
 import color from '../../config/statusColor';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/OutputTab.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/OutputTab.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import color from '../../config/statusColor';
+
 import i18n from '../../../i18n';
+import color from '../../config/statusColor';
 
 const getMessage = status => {
   switch (status) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/RematchButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/RematchButton.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import cn from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 
-import * as selectors from '../../selectors';
+import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import { connect } from 'react-redux';
+
 import i18n from '../../../i18n';
 import {
   sendOfferToRematch,
   sendRejectToRematch,
   sendAcceptToRematch,
 } from '../../middlewares/Game';
+import * as selectors from '../../selectors';
 
 const getPlayerStatus = (rematchInitiatorId, currentUserId) => {
   if (rematchInitiatorId === null) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/ReplayerControlButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/ReplayerControlButton.jsx
@@ -1,11 +1,13 @@
 import React, { useContext, useCallback } from 'react';
+
 import { useDispatch } from 'react-redux';
-import RoomContext from '../../components/RoomContext';
+
 import i18n from '../../../i18n';
-import { actions } from '../../slices';
-import { downloadPlaybook, openPlaybook } from '../../middlewares/Game';
+import RoomContext from '../../components/RoomContext';
 import { replayerMachineStates, roomMachineStates } from '../../machines/game';
 import { inPreviewRoomSelector, roomStateSelector } from '../../machines/selectors';
+import { downloadPlaybook, openPlaybook } from '../../middlewares/Game';
+import { actions } from '../../slices';
 import useMachineStateSelector from '../../utils/useMachineStateSelector';
 
 function ReplayerControlButton() {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/SignUpButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/SignUpButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import i18n from '../../../i18n';
 
 const SignUpButton = () => (

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/StartTrainingButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/StartTrainingButton.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+
 import find from 'lodash/find';
+import { useSelector } from 'react-redux';
+
 import i18n from '../../../i18n';
 import * as selectors from '../../selectors';
 import { getCreateTrainingGameUrl } from '../../utils/urlBuilders';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskAssignment.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskAssignment.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+
 import isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
+
 import i18n from '../../../i18n';
-import { actions } from '../../slices';
-import ContributorsList from './ContributorsList';
 import GameLevelBadge from '../../components/GameLevelBadge';
-import TaskLanguagesSelection from './TaskLanguageSelection';
-import TaskDescriptionMarkdown from './TaskDescriptionMarkdown';
+import { actions } from '../../slices';
 import useTaskDescriptionParams from '../../utils/useTaskDescriptionParams';
+
+import ContributorsList from './ContributorsList';
+import TaskDescriptionMarkdown from './TaskDescriptionMarkdown';
+import TaskLanguagesSelection from './TaskLanguageSelection';
 
 const renderTaskLink = name => {
   const link = `https://github.com/hexlet-codebattle/battle_asserts/tree/master/src/battle_asserts/issues/${name}.clj`;

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskDescriptionMarkdown.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskDescriptionMarkdown.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ReactMarkdown from 'react-markdown';
 
 const TaskDescriptionMarkdown = ({ description }) => (

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskLanguageSelection.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/TaskLanguageSelection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Dropdown from 'react-bootstrap/Dropdown';
 
 const TaskLanguagesSelection = ({

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/TimerContainer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/TimerContainer.jsx
@@ -1,12 +1,13 @@
 import React, { useContext } from 'react';
+
 import CountdownTimer from '../../components/CountdownTimer';
-import Timer from '../../components/Timer';
 import RoomContext from '../../components/RoomContext';
+import Timer from '../../components/Timer';
 import GameRoomModes from '../../config/gameModes';
-import useMachineStateSelector from '../../utils/useMachineStateSelector';
-import { roomStateSelector, taskStateSelector } from '../../machines/selectors';
 import { roomMachineStates } from '../../machines/game';
+import { roomStateSelector, taskStateSelector } from '../../machines/selectors';
 import { taskMachineStates } from '../../machines/task';
+import useMachineStateSelector from '../../utils/useMachineStateSelector';
 
 const gameStatuses = {
   stored: 'stored',

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/UserGameScore.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/UserGameScore.jsx
@@ -1,6 +1,8 @@
 import React, { memo } from 'react';
+
 import cn from 'classnames';
 import { useSelector } from 'react-redux';
+
 import { userGameScoreSelector } from '../../selectors';
 
 function UserGameScore({ userId }) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/VimModeButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/VimModeButton.jsx
@@ -1,6 +1,8 @@
-import cn from 'classnames';
 import React from 'react';
+
+import cn from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
+
 import editorModes from '../../config/editorModes';
 import { editorsModeSelector } from '../../selectors';
 import { actions } from '../../slices';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/WaitingOpponentInfo.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/WaitingOpponentInfo.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import i18n from 'i18next';
+
 import CopyButton from '../../components/CopyButton';
 
 function WaitingOpponentInfo({ gameUrl }) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/ChatActionModal.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/ChatActionModal.jsx
@@ -1,12 +1,14 @@
 import React, {
   useCallback,
 } from 'react';
+
 import Modal from 'react-bootstrap/Modal';
 import { useDispatch, useSelector } from 'react-redux';
-import * as lobbyMiddlewares from '../../middlewares/Lobby';
-import { actions } from '../../slices';
-import * as selectors from '../../selectors';
+
 import UserInfo from '../../components/UserInfo';
+import * as lobbyMiddlewares from '../../middlewares/Lobby';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
 
 function ChatActionModal({
   presenceList,

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
@@ -1,18 +1,20 @@
-import moment from 'moment';
 import React, {
   memo,
   useEffect,
   useMemo,
   useRef,
 } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import cn from 'classnames';
 
-import GameCard from './GameCard';
-import UserInfo from '../../components/UserInfo';
+import cn from 'classnames';
+import moment from 'moment';
+import { useDispatch, useSelector } from 'react-redux';
+
 import GameLevelBadge from '../../components/GameLevelBadge';
 import ResultIcon from '../../components/ResultIcon';
 import HorizontalScrollControls from '../../components/SideScrollControls';
+import UserInfo from '../../components/UserInfo';
+
+import GameCard from './GameCard';
 
 const CompletedGamesRows = memo(({ games }) => (
   <>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CreateGameDialog.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CreateGameDialog.jsx
@@ -1,19 +1,21 @@
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import AsyncSelect from 'react-select/async';
 import axios from 'axios';
-import qs from 'qs';
+import cn from 'classnames';
 import { camelizeKeys } from 'humps';
 import get from 'lodash/get';
+import qs from 'qs';
+import { useDispatch, useSelector } from 'react-redux';
+import AsyncSelect from 'react-select/async';
 
-import * as selectors from '../../selectors';
-import { actions } from '../../slices';
-import * as lobbyMiddlewares from '../../middlewares/Lobby';
-import * as invitesMiddleware from '../../middlewares/Invite';
 import i18n from '../../../i18n';
 import levelRatio from '../../config/levelRatio';
+import * as invitesMiddleware from '../../middlewares/Invite';
+import * as lobbyMiddlewares from '../../middlewares/Lobby';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
+
 import TaskChoice from './TaskChoice';
 
 const TIMEOUT = 480;

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameActionButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameActionButton.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+
+import copy from 'copy-to-clipboard';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
-import copy from 'copy-to-clipboard';
-import { getSignInGithubUrl, makeGameUrl } from '../../utils/urlBuilders';
+
 import i18n from '../../../i18n';
 import gameStateCodes from '../../config/gameStateCodes';
 import * as lobbyMiddlewares from '../../middlewares/Lobby';
+import { getSignInGithubUrl, makeGameUrl } from '../../utils/urlBuilders';
+
 import ShowButton from './ShowButton';
 
 const havePlayer = (userId, game) => !isEmpty(find(game.players, { id: userId }));

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameCard.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameCard.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import UserInfo from '../../components/UserInfo';
+
 import GameLevelBadge from '../../components/GameLevelBadge';
-import GameStateBadge from './GameStateBadge';
-import GameProgressBar from './GameProgressBar';
-import GameActionButton from './GameActionButton';
 import ResultIcon from '../../components/ResultIcon';
+import UserInfo from '../../components/UserInfo';
 import { loadSimpleUserStats } from '../../middlewares/Users';
+
+import GameActionButton from './GameActionButton';
+import GameProgressBar from './GameProgressBar';
+import GameStateBadge from './GameStateBadge';
 
 const getPerfomance = (won, lost) => {
   if (lost === 0) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameProgressBar.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameProgressBar.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import cn from 'classnames';
+
 import PlayerLoading from '../../components/PlayerLoading';
 
 const getPregressbarClass = player => cn('cb-check-result-bar shadow-sm', player.checkResult.status);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameRoomPreview.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/GameRoomPreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import Gon from 'gon';
+
 import LanguageIcon from '../../components/LanguageIcon';
 
 const defaultAvatarUrl = 'https://avatars.githubusercontent.com/u/35539033?v=4';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/Leaderboard.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/Leaderboard.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import Table from 'react-bootstrap/Table';
+
 import classnames from 'classnames';
+import Table from 'react-bootstrap/Table';
+import { useSelector, useDispatch } from 'react-redux';
+
 import UserInfo from '../../components/UserInfo';
+import periodTypes from '../../config/periodTypes';
 import { actions } from '../../slices';
 import { leaderboardSelector } from '../../slices/leaderboard';
-import periodTypes from '../../config/periodTypes';
 
 function Leaderboard() {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyChat.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyChat.jsx
@@ -1,20 +1,22 @@
 import React, { useEffect, useMemo, useCallback } from 'react';
-import { connect, useSelector } from 'react-redux';
-import groupBy from 'lodash/groupBy';
-import cn from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
-import * as selectors from '../../selectors';
-import * as chatMiddlewares from '../../middlewares/Chat';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import groupBy from 'lodash/groupBy';
+import { connect, useSelector } from 'react-redux';
+
+import ChatContextMenu from '../../components/ChatContextMenu';
+import ChatHeader from '../../components/ChatHeader';
+import ChatInput from '../../components/ChatInput';
+import Loading from '../../components/Loading';
 import Messages from '../../components/Messages';
 import UserInfo from '../../components/UserInfo';
-import ChatInput from '../../components/ChatInput';
-import ChatHeader from '../../components/ChatHeader';
-import ChatContextMenu from '../../components/ChatContextMenu';
-import Loading from '../../components/Loading';
+import * as chatMiddlewares from '../../middlewares/Chat';
+import * as selectors from '../../selectors';
+import { shouldShowMessage } from '../../utils/chat';
 import useChatContextMenu from '../../utils/useChatContextMenu';
 import useChatRooms from '../../utils/useChatRooms';
-import { shouldShowMessage } from '../../utils/chat';
 
 function ChatGroupedPlayersList({ players, displayMenu }) {
   const {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
@@ -4,42 +4,44 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
+
+import cn from 'classnames';
+import Gon from 'gon';
 import find from 'lodash/find';
-import isEmpty from 'lodash/isEmpty';
-import sortBy from 'lodash/sortBy';
-import orderBy from 'lodash/orderBy';
 import groupBy from 'lodash/groupBy';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import sortBy from 'lodash/sortBy';
 import moment from 'moment';
 import Modal from 'react-bootstrap/Modal';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
-
 import { useDispatch, useSelector } from 'react-redux';
-import Gon from 'gon';
-import cn from 'classnames';
-import * as lobbyMiddlewares from '../../middlewares/Lobby';
-import gameStateCodes from '../../config/gameStateCodes';
-import { actions } from '../../slices';
-import * as selectors from '../../selectors';
-import UserInfo from '../../components/UserInfo';
-import CompletedGames from './CompletedGames';
-import ChatActionModal from './ChatActionModal';
-import CreateGameDialog from './CreateGameDialog';
-import Leaderboard from './Leaderboard';
-import Announcement from './Announcement';
+
 import GameLevelBadge from '../../components/GameLevelBadge';
-import LobbyChat from './LobbyChat';
+import HorizontalScrollControls from '../../components/SideScrollControls';
+import UserInfo from '../../components/UserInfo';
+import gameStateCodes from '../../config/gameStateCodes';
+import hashLinkNames from '../../config/hashLinkNames';
+import levelRatio from '../../config/levelRatio';
+import * as lobbyMiddlewares from '../../middlewares/Lobby';
+import * as selectors from '../../selectors';
+import { actions } from '../../slices';
+import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
+import { getLobbyUrl } from '../../utils/urlBuilders';
+
+import Announcement from './Announcement';
+import ChatActionModal from './ChatActionModal';
+import CompletedGames from './CompletedGames';
+import CreateGameDialog from './CreateGameDialog';
+import GameActionButton from './GameActionButton';
 import GameCard from './GameCard';
-import TournamentCard from './TournamentCard';
 import GameProgressBar from './GameProgressBar';
 import GameStateBadge from './GameStateBadge';
+import Leaderboard from './Leaderboard';
+import LobbyChat from './LobbyChat';
 import ShowButton from './ShowButton';
-import GameActionButton from './GameActionButton';
-import HorizontalScrollControls from '../../components/SideScrollControls';
-import { getLobbyUrl } from '../../utils/urlBuilders';
-import levelRatio from '../../config/levelRatio';
-import hashLinkNames from '../../config/hashLinkNames';
-import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
+import TournamentCard from './TournamentCard';
 
 const isActiveGame = game => [gameStateCodes.playing, gameStateCodes.waitingOpponent].includes(game.state);
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
@@ -29,7 +29,7 @@ import * as lobbyMiddlewares from '../../middlewares/Lobby';
 import * as selectors from '../../selectors';
 import { actions } from '../../slices';
 import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
-import { getLobbyUrl } from '../../utils/urlBuilders';
+import { getLobbyUrl, makeGameUrl } from '../../utils/urlBuilders';
 
 import Announcement from './Announcement';
 import ChatActionModal from './ChatActionModal';
@@ -42,13 +42,7 @@ import GameStateBadge from './GameStateBadge';
 import Leaderboard from './Leaderboard';
 import LobbyChat from './LobbyChat';
 import ShowButton from './ShowButton';
-import TournamentCard from './';
-import GameActionButton from './GameActionButton';
-import HorizontalScrollControls from '../../components/SideScrollControls';
-import { getLobbyUrl, makeGameUrl } from '../../utils/urlBuilders';
-import levelRatio from '../../config/levelRatio';
-import hashLinkNames from '../../config/hashLinkNames';
-import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
+import TournamentCard from './TournamentCard';
 
 const isActiveGame = game => [gameStateCodes.playing, gameStateCodes.waitingOpponent].includes(game.state);
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/TaskChoice.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/TaskChoice.jsx
@@ -1,19 +1,20 @@
 import React, { useState, useEffect } from 'react';
+
+import { faShuffle, faUser } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import axios from 'axios';
+import cn from 'classnames';
+import Gon from 'gon';
+import { camelizeKeys } from 'humps';
+import get from 'lodash/get';
+import has from 'lodash/has';
+import intersection from 'lodash/intersection';
 import { useDispatch, useSelector } from 'react-redux';
 import Select from 'react-select';
-import Gon from 'gon';
-import cn from 'classnames';
-import { camelizeKeys } from 'humps';
-import axios from 'axios';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faShuffle, faUser } from '@fortawesome/free-solid-svg-icons';
-import has from 'lodash/has';
-import get from 'lodash/get';
-import intersection from 'lodash/intersection';
 
+import i18n from '../../../i18n';
 import * as selectors from '../../selectors';
 import { actions } from '../../slices';
-import i18n from '../../../i18n';
 
 const isRandomTask = task => !has(task, 'id');
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/TournamentCard.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/TournamentCard.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
+
 import moment from 'moment';
-import UserInfo from '../../components/UserInfo';
+
 import TournamentType from '../../components/TournamentType';
+import UserInfo from '../../components/UserInfo';
+
 import ShowButton from './ShowButton';
 
 function TournamentCard({

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/Heatmap.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/Heatmap.jsx
@@ -1,10 +1,11 @@
-import { useDispatch } from 'react-redux';
-import CalendarHeatmap from 'react-calendar-heatmap';
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 
-import { actions } from '../../slices';
+import axios from 'axios';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import { useDispatch } from 'react-redux';
+
 import Loading from '../../components/Loading';
+import { actions } from '../../slices';
 
 const getColorScale = count => {
   if (count >= 5) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -1,9 +1,10 @@
-import { camelizeKeys } from 'humps';
-import { useDispatch, useSelector } from 'react-redux';
-import mapValues from 'lodash/mapValues';
-import groupBy from 'lodash/groupBy';
 import React, { useState, useEffect } from 'react';
 
+import axios from 'axios';
+import { camelizeKeys } from 'humps';
+import groupBy from 'lodash/groupBy';
+import mapValues from 'lodash/mapValues';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Radar,
   RadarChart,
@@ -17,15 +18,15 @@ import {
   Tooltip,
   Legend,
 } from 'recharts';
-import axios from 'axios';
 
+import Loading from '../../components/Loading';
+import langIconNames from '../../config/langIconNames';
+import * as selectors from '../../selectors';
 import { actions } from '../../slices';
 import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 import CompletedGames from '../lobby/CompletedGames';
+
 import Heatmap from './Heatmap';
-import Loading from '../../components/Loading';
-import * as selectors from '../../selectors';
-import langIconNames from '../../config/langIconNames';
 
 function UserProfile() {
   const [stats, setStats] = useState(null);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/rating/RatingList.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/rating/RatingList.jsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Pagination from 'react-js-pagination';
-import moment from 'moment';
 import cn from 'classnames';
+import moment from 'moment';
+import Pagination from 'react-js-pagination';
+import { useSelector, useDispatch } from 'react-redux';
 
 import UserInfo from '../../components/UserInfo';
-import { usersListSelector } from '../../selectors';
 import { getUsersRatingPage } from '../../middlewares/Users';
+import { usersListSelector } from '../../selectors';
 
 const decorateJoinedDate = str => moment.utc(str).format('LL');
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/registration/Registration.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/registration/Registration.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
+
 import axios from 'axios';
+import cn from 'classnames';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
-import cn from 'classnames';
 
 const getCsrfToken = () => document
   .querySelector("meta[name='csrf-token']")

--- a/services/app/apps/codebattle/assets/js/widgets/pages/settings/UserSettings.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/settings/UserSettings.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import capitalize from 'lodash/capitalize';
-import cn from 'classnames';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import capitalize from 'lodash/capitalize';
+import { useDispatch, useSelector } from 'react-redux';
+
 import Loading from '../../components/Loading';
-import UserSettingsForm from './UserSettingsForm';
 import { userSettingsSelector } from '../../selectors';
 import { updateUserSettings } from '../../slices/userSettings';
+
+import UserSettingsForm from './UserSettingsForm';
 
 const PROVIDERS = ['github', 'discord'];
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/settings/UserSettingsForm.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/settings/UserSettingsForm.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import capitalize from 'lodash/capitalize';
+
+import Slider from 'calcite-react/Slider';
 import {
  Formik, Form, Field, useField,
 } from 'formik';
-import * as Yup from 'yup';
-import Slider from 'calcite-react/Slider';
+import capitalize from 'lodash/capitalize';
 import * as Icon from 'react-feather';
+import * as Yup from 'yup';
+
 import languages from '../../config/languages';
 import { createPlayer } from '../../lib/sound';
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/IndividualIntendedPlayersPanel.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/IndividualIntendedPlayersPanel.jsx
@@ -1,8 +1,9 @@
 import React, { memo } from 'react';
-import JoinButton from './JoinButton';
 
-import TournamentStates from '../../config/tournament';
 import UserInfo from '../../components/UserInfo';
+import TournamentStates from '../../config/tournament';
+
+import JoinButton from './JoinButton';
 
 const Players = ({ players }) => (
   <div className="my-3">

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/IndividualMatches.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/IndividualMatches.jsx
@@ -1,11 +1,12 @@
 import React, {
  memo, useMemo,
 } from 'react';
-import capitalize from 'lodash/capitalize';
-import cn from 'classnames';
 
-import TournamentStates from '../../config/tournament';
+import cn from 'classnames';
+import capitalize from 'lodash/capitalize';
+
 import UserInfo from '../../components/UserInfo';
+import TournamentStates from '../../config/tournament';
 import useTimer from '../../utils/useTimer';
 
 const RoundTypes = {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/JoinButton.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/JoinButton.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import cn from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+
 import { leaveTournament, joinTournament } from '../../middlewares/Tournament';
 
 const JoinButton = ({

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/PlayerPicker.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/PlayerPicker.jsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
+
 import Select from 'react-select';
+
 import UserInfo from '../../components/UserInfo';
 
 const customStyle = {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayEditorContainer.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayEditorContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+
 import find from 'lodash/find';
+import { useSelector } from 'react-redux';
 
 import Editor from '../../components/Editor';
 import { currentUserIdSelector } from '../../selectors';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayEditorToolbar.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayEditorToolbar.jsx
@@ -1,13 +1,15 @@
-import find from 'lodash/find';
 import React, { useCallback, useMemo } from 'react';
+
+import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
-import { actions } from '../../slices';
 
 import LanguagePickerView from '../../components/LanguagePickerView';
+import { currentUserIdSelector } from '../../selectors';
+import { actions } from '../../slices';
+import DarkModeButton from '../game/DarkModeButton';
 import GameActionButtons from '../game/GameActionButtons';
 import VimModeButton from '../game/VimModeButton';
-import DarkModeButton from '../game/DarkModeButton';
-import { currentUserIdSelector } from '../../selectors';
+
 import PlayerPicker from './PlayerPicker';
 
 const type = 'stairway';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayGameInfo.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayGameInfo.jsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 
 import find from 'lodash/find';
+
 import TaskAssignment from '../game/TaskAssignment';
 
 const StairwayGameInfo = ({ tasks, currentTaskId }) => {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayOutputTab.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayOutputTab.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useSelector } from 'react-redux';
 
 import Output from '../game/Output';

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayRounds.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/StairwayRounds.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import cn from 'classnames';
 
 const StairwayRounds = ({

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TeamMatches.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TeamMatches.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, memo } from 'react';
 
 import reverse from 'lodash/reverse';
+
 import UserInfo from '../../components/UserInfo';
 
 const calcRoundResult = matches => matches.reduce((acc, match) => {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/Tournament.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/Tournament.jsx
@@ -1,20 +1,21 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
+
+import TournamentStates from '../../config/tournament';
+import { connectToChat } from '../../middlewares/Chat';
 import {
   connectToTournament,
   kickFromTournament,
 } from '../../middlewares/Tournament';
-import { connectToChat } from '../../middlewares/Chat';
-
 import * as selectors from '../../selectors';
-import TournamentStates from '../../config/tournament';
 
-import TournamentChat from './TournamentChat';
-import Players from './Participants';
 import IndividualMatches from './IndividualMatches';
+import Players from './Participants';
+import TeamMatches from './TeamMatches';
+import TournamentChat from './TournamentChat';
 import TournamentHeader from './TournamentHeader';
 // import TeamTournamentInfoPanel from './TeamTournamentInfoPanel';
-import TeamMatches from './TeamMatches';
 
 function Tournament() {
   const dispatch = useDispatch();

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentChat.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentChat.jsx
@@ -3,18 +3,18 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+
 import { useSelector } from 'react-redux';
 
+import ChatContextMenu from '../../components/ChatContextMenu';
+import Messages from '../../components/Messages';
+import Rooms from '../../components/Rooms';
+import { pushCommand, pushCommandTypes } from '../../middlewares/Chat';
+import * as selectors from '../../selectors';
 import useChatContextMenu from '../../utils/useChatContextMenu';
 import useChatRooms from '../../utils/useChatRooms';
 
-import ChatContextMenu from '../../components/ChatContextMenu';
-import Rooms from '../../components/Rooms';
 import TournamentChatInput from './TournamentChatInput';
-import Messages from '../../components/Messages';
-
-import { pushCommand, pushCommandTypes } from '../../middlewares/Chat';
-import * as selectors from '../../selectors';
 
 function TournamentChat() {
   const currentUserIsAdmin = useSelector(selectors.currentUserIsAdminSelector);

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentChatInput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentChatInput.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
+
 import { addMessage } from '../../middlewares/Chat';
 
 export default function TournamentChatInput({ disabled }) {

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentHeader.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentHeader.jsx
@@ -2,18 +2,20 @@ import React, {
   memo,
   useMemo,
 } from 'react';
-import cn from 'classnames';
 
-import { useSelector } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cn from 'classnames';
+import { useSelector } from 'react-redux';
+
+import CopyButton from '../../components/CopyButton';
+import GameLevelBadge from '../../components/GameLevelBadge';
+import Loading from '../../components/Loading';
+import TournamentType from '../../components/TournamentType';
 import TournamentStates from '../../config/tournament';
+import * as selectors from '../../selectors';
+
 import JoinButton from './JoinButton';
 import TournamentMainControlButtons from './TournamentMainControlButtons';
-import GameLevelBadge from '../../components/GameLevelBadge';
-import * as selectors from '../../selectors';
-import Loading from '../../components/Loading';
-import CopyButton from '../../components/CopyButton';
-import TournamentType from '../../components/TournamentType';
 
 const getIconByAccessType = accessType => (
   accessType === 'token'

--- a/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentMainControlButtons.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/tournament/TournamentMainControlButtons.jsx
@@ -1,6 +1,8 @@
 import React, { memo } from 'react';
-import Dropdown from 'react-bootstrap/Dropdown';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Dropdown from 'react-bootstrap/Dropdown';
+
 import {
   cancelTournament as handleCancelTournament,
   startTournament as handleStartTournament,

--- a/services/app/apps/codebattle/assets/js/widgets/selectors/index.js
+++ b/services/app/apps/codebattle/assets/js/widgets/selectors/index.js
@@ -1,18 +1,19 @@
 import { createDraftSafeSelector } from '@reduxjs/toolkit';
-import isUndefined from 'lodash/isUndefined';
 import find from 'lodash/find';
 import get from 'lodash/get';
-import pick from 'lodash/pick';
 import hasIn from 'lodash/hasIn';
-import userTypes from '../config/userTypes';
-import GameStateCodes from '../config/gameStateCodes';
-import editorModes from '../config/editorModes';
-import editorThemes from '../config/editorThemes';
+import isUndefined from 'lodash/isUndefined';
+import pick from 'lodash/pick';
+
 import i18n from '../../i18n';
-import { makeEditorTextKey } from '../utils/gameRoom';
+import editorModes from '../config/editorModes';
 import defaultEditorHeight from '../config/editorSettings';
-import { replayerMachineStates } from '../machines/game';
+import editorThemes from '../config/editorThemes';
+import GameStateCodes from '../config/gameStateCodes';
 import { taskStateCodes } from '../config/task';
+import userTypes from '../config/userTypes';
+import { replayerMachineStates } from '../machines/game';
+import { makeEditorTextKey } from '../utils/gameRoom';
 
 export const currentUserIdSelector = state => state.user.currentUserId;
 

--- a/services/app/apps/codebattle/assets/js/widgets/slices/builder.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/builder.js
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import capitalize from 'lodash/capitalize';
 import remove from 'lodash/remove';
+
 import {
   validateTaskName,
   validateDescription,
@@ -10,6 +11,7 @@ import {
   getExamplesFromAsserts,
   getTaskTemplates,
 } from '../utils/builder';
+
 import initial from './initial';
 
 const getTaskAssertsStatus = task => ({

--- a/services/app/apps/codebattle/assets/js/widgets/slices/chat.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/chat.js
@@ -1,11 +1,11 @@
 import { createSlice, current } from '@reduxjs/toolkit';
 
 import defaultRooms from '../config/rooms';
+import { ttl, filterPrivateRooms } from '../middlewares/Room';
 import {
   isMessageForCurrentUser,
   isMessageForCurrentPrivateRoom,
 } from '../utils/chat';
-import { ttl, filterPrivateRooms } from '../middlewares/Room';
 
 const initialState = {
   users: [],

--- a/services/app/apps/codebattle/assets/js/widgets/slices/completedGames.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/completedGames.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 import { camelizeKeys } from 'humps';
 import unionBy from 'lodash/unionBy';
 
-import { actions as lobbyActions } from './lobby';
 import initial from './initial';
+import { actions as lobbyActions } from './lobby';
 
 export const fetchCompletedGames = createAsyncThunk(
   'completedGames/fetchCompletedGames',

--- a/services/app/apps/codebattle/assets/js/widgets/slices/editor.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/editor.js
@@ -1,6 +1,8 @@
 import { combineReducers, createSlice } from '@reduxjs/toolkit';
+
 import defaultEditorHeight from '../config/editorSettings';
 import { makeEditorTextKey } from '../utils/gameRoom';
+
 import initial from './initial';
 
 const getCurrentEditorHeight = (state, userId) => {

--- a/services/app/apps/codebattle/assets/js/widgets/slices/executionOutput.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/executionOutput.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+
 import initial from './initial';
 
 const executionOutput = createSlice({

--- a/services/app/apps/codebattle/assets/js/widgets/slices/game.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/game.js
@@ -1,6 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import omit from 'lodash/omit';
+
 import { setPlayerToSliceState } from '../utils/gameRoom';
+
 import initial from './initial';
 
 const initialState = initial.game;

--- a/services/app/apps/codebattle/assets/js/widgets/slices/gameUI.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/gameUI.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+
 import editorModes from '../config/editorModes';
 import editorThemes from '../config/editorThemes';
 import taskDescriptionLanguages from '../config/taskDescriptionLanguages';

--- a/services/app/apps/codebattle/assets/js/widgets/slices/index.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/index.js
@@ -1,24 +1,24 @@
+import builder, { actions as builderActions } from './builder';
 import chat, { actions as chatActions } from './chat';
 import completedGames, {
   actions as completedGamesActions,
 } from './completedGames';
 import editor, { actions as editorActions } from './editor';
-import storeLoaded, { actions as storeLoadedActions } from './store';
-import usersInfo, { actions as usersInfoActions } from './usersInfo';
-import gameUI, { actions as gameUIActions } from './gameUI';
 import executionOutput, {
   actions as executionOutputActions,
 } from './executionOutput';
-import playbook, { actions as playbookActions } from './playbook';
 import game, { actions as gameActions } from './game';
-import builder, { actions as builderActions } from './builder';
+import gameUI, { actions as gameUIActions } from './gameUI';
+import invites, { actions as invitesActions } from './invites';
+import leaderboard, { actions as leaderboardActions } from './leaderboard';
 import lobby, { actions as lobbyActions } from './lobby';
+import playbook, { actions as playbookActions } from './playbook';
+import stairwayGame, { actions as stairwayGameActions } from './stairway';
+import storeLoaded, { actions as storeLoadedActions } from './store';
+import tournament, { actions as tournamentActions } from './tournament';
 import user, { actions as userActions } from './user';
 import userSettings, { actions as userSettingActions } from './userSettings';
-import leaderboard, { actions as leaderboardActions } from './leaderboard';
-import invites, { actions as invitesActions } from './invites';
-import stairwayGame, { actions as stairwayGameActions } from './stairway';
-import tournament, { actions as tournamentActions } from './tournament';
+import usersInfo, { actions as usersInfoActions } from './usersInfo';
 
 const setError = error => ({
   type: 'ERROR',

--- a/services/app/apps/codebattle/assets/js/widgets/slices/initial.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/initial.js
@@ -1,6 +1,10 @@
-import { camelizeKeys } from 'humps';
 import Gon from 'gon';
+import { camelizeKeys } from 'humps';
+
+import GameRoomModes from '../config/gameModes';
+import GameStateCodes from '../config/gameStateCodes';
 import { taskStateCodes, taskVisibilityCodes } from '../config/task';
+import userTypes from '../config/userTypes';
 import {
   validateTaskName,
   validateInputSignatures,
@@ -17,9 +21,6 @@ import {
   makeEditorTextKey,
   setPlayerToSliceState,
 } from '../utils/gameRoom';
-import GameStateCodes from '../config/gameStateCodes';
-import GameRoomModes from '../config/gameModes';
-import userTypes from '../config/userTypes';
 
 const currentUserParams = Gon.getAsset('current_user');
 const isRecord = Gon.getAsset('is_record') || false;

--- a/services/app/apps/codebattle/assets/js/widgets/slices/leaderboard.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/leaderboard.js
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
 import moment from 'moment';
+
 import periodTypes from '../config/periodTypes';
 
 const periodMapping = {

--- a/services/app/apps/codebattle/assets/js/widgets/slices/lobby.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/lobby.js
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
-import reject from 'lodash/reject';
 import find from 'lodash/find';
+import reject from 'lodash/reject';
+
 import initial from './initial';
 
 const initialState = {

--- a/services/app/apps/codebattle/assets/js/widgets/slices/playbook.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/playbook.js
@@ -1,6 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
+
 import SolutionTypeCodes from '../config/solutionTypes';
 import { addRecord, parse } from '../lib/player';
+
 import { actions as editorActions } from './editor';
 import { actions as executionOutputActions } from './executionOutput';
 

--- a/services/app/apps/codebattle/assets/js/widgets/slices/tournament.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/tournament.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+
 import initial from './initial';
 
 const initialState = initial.tournament;

--- a/services/app/apps/codebattle/assets/js/widgets/slices/user.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/user.js
@@ -1,5 +1,6 @@
-import isEmpty from 'lodash/isEmpty';
 import { createSlice } from '@reduxjs/toolkit';
+import isEmpty from 'lodash/isEmpty';
+
 import initial from './initial';
 
 const userSlice = createSlice({

--- a/services/app/apps/codebattle/assets/js/widgets/slices/userSettings.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/userSettings.js
@@ -1,6 +1,6 @@
-import Gon from 'gon';
-import axios from 'axios';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+import Gon from 'gon';
 import capitalize from 'lodash/capitalize';
 
 const userSettings = Gon.getAsset('current_user');

--- a/services/app/apps/codebattle/assets/js/widgets/utils/editor.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/editor.js
@@ -1,5 +1,5 @@
-import languageTabSizes from '../config/languageTabSizes';
 import langToSpacesMapping from '../config/langToSpacesMapping';
+import languageTabSizes from '../config/languageTabSizes';
 
 const getLanguageTabSize = language => {
   const defaultTabSize = 2;

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useChatContextMenu.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useChatContextMenu.js
@@ -1,4 +1,5 @@
 import { useCallback, useState, useMemo } from 'react';
+
 import { useContextMenu } from 'react-contexify';
 
 const useChatContextMenu = ({

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useChatRooms.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useChatRooms.js
@@ -1,5 +1,7 @@
-import { useSelector, useDispatch } from 'react-redux';
 import { useEffect, useMemo } from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
 import {
   getPrivateRooms,
   filterPrivateRooms,
@@ -7,8 +9,9 @@ import {
   clearExpiredPrivateRooms,
   updatePrivateRooms,
 } from '../middlewares/Room';
-import { actions } from '../slices';
 import * as selectors from '../selectors';
+import { actions } from '../slices';
+
 import getChatName from './names';
 
 const useChatRooms = key => {

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useGameRoomMachine.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useGameRoomMachine.js
@@ -1,5 +1,6 @@
 import { useInterpret } from '@xstate/react';
 import { useDispatch } from 'react-redux';
+
 import { actions } from '../slices';
 
 const useGameRoomMachine = ({

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useKey.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useKey.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import { useMemo } from 'react';
+
 import useEvent from './useEvent';
 
 const noop = () => { };

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useTaskDescriptionParams.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useTaskDescriptionParams.js
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
-import keys from 'lodash/keys';
+
 import includes from 'lodash/includes';
+import keys from 'lodash/keys';
+
 import taskDescriptionLanguages from '../config/taskDescriptionLanguages';
 
 const useTaskDescriptionParams = (task, taskLanguage) => useMemo(() => {

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useTimer.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useTimer.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+
 import moment from 'moment';
 
 function useTimer(time) {

--- a/services/app/apps/codebattle/assets/js/widgets/utils/useValidationExample.js
+++ b/services/app/apps/codebattle/assets/js/widgets/utils/useValidationExample.js
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
-import isBoolean from 'lodash/isBoolean';
+
 import isArray from 'lodash/isArray';
-import isObject from 'lodash/isObject';
+import isBoolean from 'lodash/isBoolean';
 import isEmpty from 'lodash/isEmpty';
+import isNumber from 'lodash/isNumber';
+import isObject from 'lodash/isObject';
+import isString from 'lodash/isString';
+
 import { argumentTypes } from './builder';
 
 const isValidValueToSignature = (value, signature) => {

--- a/services/app/apps/codebattle/jsconfig.json
+++ b/services/app/apps/codebattle/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",                                     /* Specify the base directory to resolve non-relative module names. */
+    "paths": {
+      "@/*": ["./assets/js/widgets/*"]
+    },                                         /* Specify a set of entries that re-map imports to additional lookup locations. */
+  },
+  "exclude": [
+    "node_modules", "webpack", "lib", "test", "priv"
+  ],
+}

--- a/services/app/apps/codebattle/package.json
+++ b/services/app/apps/codebattle/package.json
@@ -19,7 +19,15 @@
     "verbose": true,
     "moduleNameMapper": {
       "monaco-editor": "<rootDir>/node_modules/react-monaco-editor",
-      "^.+\\.(css|styl|less|sass|scss|po|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
+      "^.+\\.(css|styl|less|sass|scss|po|png|jpg|ttf|woff|woff2)$": "jest-transform-stub",
+      "^@/components(.*)$": "<rootDir>/assets/js/widgets/components$1",
+      "^@/lib(.*)$": "<rootDir>/assets/js/widgets/lib$1",
+      "^@/machines(.*)$": "<rootDir>/assets/js/widgets/machines$1",
+      "^@/middlewares(.*)$": "<rootDir>/assets/js/widgets/middlewares$1",
+      "^@/pages(.*)$": "<rootDir>/assets/js/widgets/pages$1",
+      "^@/selectors(.*)$": "<rootDir>/assets/js/widgets/selectors$1",
+      "^@/slices(.*)$": "<rootDir>/assets/js/widgets/slices$1",
+      "^@/utils(.*)$": "<rootDir>/assets/js/widgets/utils$1"
     },
     "testPathIgnorePatterns": [
       "/helpers/"

--- a/services/app/apps/codebattle/webpack/webpack.base.config.js
+++ b/services/app/apps/codebattle/webpack/webpack.base.config.js
@@ -1,20 +1,23 @@
 const path = require('path');
-const webpack = require('webpack');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const env = process.env.NODE_ENV || 'development';
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const webpack = require('webpack');
+
+// const env = process.env.NODE_ENV || 'development';
 // const isProd = env === 'production';
 
 function recursiveIssuer(m) {
   if (m.issuer) {
     return recursiveIssuer(m.issuer);
-  } else if (m.name) {
-    return m.name;
-  } else {
-    return false;
   }
+
+  if (m.name) {
+    return m.name;
+  }
+
+  return false;
 }
 
 module.exports = {
@@ -29,6 +32,7 @@ module.exports = {
     sourceMapFilename: '[name].js.map',
     chunkFilename: '[id].[contenthash].js',
     publicPath: '/assets/',
+    clean: true,
   },
   externals: {
     gon: 'Gon',
@@ -72,15 +76,13 @@ module.exports = {
       cacheGroups: {
         appStyles: {
           name: 'app',
-          test: (m, c, entry = 'app') =>
-            m.constructor.name === 'CssModule' && recursiveIssuer(m) === entry,
+          test: (m, _, entry = 'app') => m.constructor.name === 'CssModule' && recursiveIssuer(m) === entry,
           chunks: 'all',
           enforce: true,
         },
         landingStyles: {
           name: 'landing',
-          test: (m, c, entry = 'landing') =>
-            m.constructor.name === 'CssModule' && recursiveIssuer(m) === entry,
+          test: (m, _, entry = 'landing') => m.constructor.name === 'CssModule' && recursiveIssuer(m) === entry,
           chunks: 'all',
           enforce: true,
         },
@@ -123,6 +125,15 @@ module.exports = {
   resolve: {
     alias: {
       './defineProperty': '@babel/runtime/helpers/esm/defineProperty',
+      '@/': path.resolve(__dirname, '../assets/js/widgets'),
+      '@/components': path.resolve(__dirname, '../assets/js/widgets/components'),
+      '@/lib': path.resolve(__dirname, '../assets/js/widgets/lib'),
+      '@/machines': path.resolve(__dirname, '../assets/js/widgets/machines'),
+      '@/middlewares': path.resolve(__dirname, '../assets/js/widgets/middlewares'),
+      '@/pages': path.resolve(__dirname, '../assets/js/widgets/pages'),
+      '@/selectors': path.resolve(__dirname, '../assets/js/widgets/selectors'),
+      '@/slices': path.resolve(__dirname, '../assets/js/widgets/slices'),
+      '@/utils': path.resolve(__dirname, '../assets/js/widgets/utils'),
     },
     fallback: {
       path: require.resolve('path-browserify'),

--- a/services/app/apps/codebattle/webpack/webpack.build.config.js
+++ b/services/app/apps/codebattle/webpack/webpack.build.config.js
@@ -1,7 +1,8 @@
-const { merge } = require('webpack-merge');
-const baseWebpackConfig = require('./webpack.base.config');
-const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const { merge } = require('webpack-merge');
+
+const baseWebpackConfig = require('./webpack.base.config');
 
 const buildWebpackConfig = merge(baseWebpackConfig, {
   mode: 'production',

--- a/services/app/apps/codebattle/webpack/webpack.dev.config.js
+++ b/services/app/apps/codebattle/webpack/webpack.dev.config.js
@@ -1,7 +1,8 @@
 const webpack = require('webpack');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { merge } = require('webpack-merge');
+
 const baseWebpackConfig = require('./webpack.base.config');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const devWebpackConfig = merge(baseWebpackConfig, {
   mode: 'development',

--- a/services/app/apps/codebattle/yarn.lock
+++ b/services/app/apps/codebattle/yarn.lock
@@ -3872,20 +3872,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001460"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz#31d2e26f0a2309860ed3eff154e03890d9d851a7"
-  integrity sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==
-
-caniuse-lite@^1.0.30001517:
-  version "1.0.30001519"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz#3e7b8b8a7077e78b0eb054d69e6edf5c7df35601"
-  integrity sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001517:
+  version "1.0.30001525"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
+  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #1126

- Добавлены правила линтера для группировки импортов
- Добавлены алиасы импортов относитнльно папки widgets. Добавлен jsconfig.json и подправлен webpack config (примеры: App.jsx, ChatContextMenu.jsx)
- Поправлены импорты lodash, чтобы не импортить всю либу