### PR TITLE
[#1494] fix user info popover placement

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
@@ -5,6 +5,7 @@ import cn from 'classnames';
 import { camelizeKeys } from 'humps';
 import { useDispatch, useSelector } from 'react-redux';
 
+import Placements from '../config/placements';
 import * as selectors from '../selectors';
 import { actions } from '../slices';
 
@@ -42,7 +43,12 @@ function UserPopoverContent({ user }) {
 }
 
 function UserInfo({
-  user, hideInfo = false, truncate = false, hideOnlineIndicator = false, loading = false,
+  user,
+  hideInfo = false,
+  truncate = false,
+  hideOnlineIndicator = false,
+  loading = false,
+  placement = Placements.bottomStart,
 }) {
   const { presenceList } = useSelector(selectors.lobbyDataSelector);
   const content = useMemo(() => <UserPopoverContent user={user} />, [user]);
@@ -74,7 +80,7 @@ function UserInfo({
   return (
     <PopoverStickOnHover
       id={`user-info-${user?.id}`}
-      placement="bottom-end"
+      placement={placement}
       component={content}
     >
       <div className={userClassName}>

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserInfo.jsx
@@ -74,7 +74,7 @@ function UserInfo({
   return (
     <PopoverStickOnHover
       id={`user-info-${user?.id}`}
-      placement="bottom-start"
+      placement="bottom-end"
       component={content}
     >
       <div className={userClassName}>

--- a/services/app/apps/codebattle/assets/js/widgets/config/placements.js
+++ b/services/app/apps/codebattle/assets/js/widgets/config/placements.js
@@ -1,0 +1,17 @@
+export default {
+  auto: 'auto',
+  autoStart: 'auto-start',
+  autoEnd: 'auto-end',
+  top: 'top',
+  topStart: 'top-start',
+  topEnd: 'top-end',
+  right: 'right',
+  rightStart: 'right-start',
+  rightEnd: 'right-end',
+  bottom: 'bottom',
+  bottomStart: 'bottom-start',
+  bottomEnd: 'bottom-end',
+  left: 'left',
+  leftStart: 'left-start',
+  leftEnd: 'left-end',
+};

--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorToolbar.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorToolbar.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import LanguagePicker from '../../components/LanguagePicker';
 import UserInfo from '../../components/UserInfo';
 import GameRoomModes from '../../config/gameModes';
+import Placements from '../../config/placements';
 
 import DarkModeButton from './DarkModeButton';
 import GameActionButtons from './GameActionButtons';
@@ -57,7 +58,7 @@ const EditorToolbar = ({
             role="group"
             aria-label="User info"
           >
-            <UserInfo user={player} />
+            <UserInfo user={player} placement={Placements.bottomEnd} />
             {mode === GameRoomModes.standard && (
               <UserGameScore userId={player.id} />
             )}


### PR DESCRIPTION
Fixes #1494

-  поповер с информацией о пользователе остаётся в пределах вьюпорта на любой ширине экрана, начиная от ширины самого поповера
-  паразитный горизонтальный скролл не появляется при всплытии поповера, если поповер всплывает возле правой границы экрана