### PR TITLE
[#1495] fix charts content overflow and improve user profile stat layout

### DIFF
--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -680,10 +680,6 @@ td {
   .lead {
     font-size: 14px;
   }
-  .cb-heatmap {
-    max-width: 95%;
-    flex-basis: 95%;
-  }
 }
 
 @media screen and (min-width: $md) {

--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -674,13 +674,6 @@ td {
   .cb-heading {
     font-size: 18px;
   }
-  .cb-user-data {
-    flex: 1 1 30%;
-    max-width: 30%;
-  }
-  .cb-user-stats {
-    max-width: 70%;
-  }
   .cb-stats-number {
     font-size: 22px;
   }
@@ -700,12 +693,6 @@ td {
 }
 
 @media (max-width: $sm) {
-  .cb-user-data {
-    max-width: 100%;
-  }
-  .cb-user-stats {
-    max-width: 100%;
-  }
   .cb-heading {
     font-size: 20px;
   }

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/Heatmap.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/Heatmap.jsx
@@ -43,10 +43,10 @@ function Heatmap() {
 
   return (
     <div className="card rounded">
-      <div className="d-flex my-0 py-1 justify-content-center card-header font-weight-bold">
+      <div className="card-header py-1 font-weight-bold text-center">
         Activity
       </div>
-      <div className="card-body py-0 my-0">
+      <div className="card-body pt-3 pr-3 pb-0 pl-2">
         <CalendarHeatmap
           showWeekdayLabels
           values={activities}

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -149,12 +149,13 @@ function UserProfile() {
 
     return (
       <>
-        <div className="col-6">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="col-12 col-md-7">
+          <ResponsiveContainer aspect={1}>
             <RadarChart
               cx="50%"
               cy="50%"
-              outerRadius="80%"
+              outerRadius="70%"
+              margin={{ right: 70 }}
               data={sortedDataForRadar}
             >
               <PolarGrid />
@@ -171,8 +172,8 @@ function UserProfile() {
             </RadarChart>
           </ResponsiveContainer>
         </div>
-        <div className="col-6">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="col-10 col-md-5 mt-n5 mt-md-0 pt-md-4">
+          <ResponsiveContainer aspect={1}>
             <PieChart>
               <Pie
                 dataKey="value"
@@ -199,7 +200,7 @@ function UserProfile() {
 
   const renderStatistics = () => (
     <>
-      <div className="row my-4 justify-content-center">
+      <div className="row mt-4 justify-content-center">
         {!stats.user.isBot && (
           <div className="col-md-3 col-5 text-center">
             <div className="h1 cb-stats-number">{stats.user.rank}</div>
@@ -218,8 +219,7 @@ function UserProfile() {
         </div>
       </div>
       <div
-        className="row my-4 justify-content-center"
-        style={{ width: '100%', height: 400 }}
+        className="row justify-content-center"
       >
         {renderCustomPieChart()}
       </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
 import axios from 'axios';
+import cn from 'classnames';
 import { camelizeKeys } from 'humps';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
+import sum from 'lodash/sum';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Radar,
@@ -198,38 +200,40 @@ function UserProfile() {
     );
   };
 
-  const renderStatistics = () => (
-    <>
-      <div className="row mt-5 px-3 justify-content-center">
-        {!stats.user.isBot && (
+  const renderStatistics = () => {
+    const gamesCount = sum(Object.values(stats.stats.games));
+
+    return (
+      <>
+        <div className="row mt-5 px-3 justify-content-center">
+          {!stats.user.isBot && (
+            <div className="col col-md-3 text-center">
+              <div className="h1 cb-stats-number">{stats.user.rank}</div>
+              <p className="lead">rank</p>
+            </div>
+          )}
           <div className="col col-md-3 text-center">
-            <div className="h1 cb-stats-number">{stats.user.rank}</div>
-            <p className="lead">rank</p>
+            <div className="h1 cb-stats-number">{stats.user.rating}</div>
+            <p className="lead">elo_rating</p>
           </div>
-        )}
-        <div className="col col-md-3 text-center">
-          <div className="h1 cb-stats-number">{stats.user.rating}</div>
-          <p className="lead">elo_rating</p>
-        </div>
-        <div className="col col-md-3 text-center">
-          <div className="h1 cb-stats-number">
-            {Object.values(stats.stats.games).reduce((a, b) => a + b, 0)}
+          <div className="col col-md-3 text-center">
+            <div className="h1 cb-stats-number">
+              {gamesCount}
+            </div>
+            <p className="lead">games_played</p>
           </div>
-          <p className="lead">games_played</p>
         </div>
-      </div>
-      <div
-        className="row justify-content-center"
-      >
-        {renderCustomPieChart()}
-      </div>
-      <div className="row mt-5 mt-md-n3 mb-md-3 mb-lg-4">
-        <div className="col-md-11 col-lg-10 mx-auto">
-          <Heatmap />
+        <div className="row justify-content-center">
+          {gamesCount > 0 && renderCustomPieChart()}
         </div>
-      </div>
-    </>
-  );
+        <div className={cn('row mt-5 mb-md-3 mb-lg-4', { 'mt-md-n3': gamesCount > 0 })}>
+          <div className="col-md-11 col-lg-10 mx-auto">
+            <Heatmap />
+          </div>
+        </div>
+      </>
+    );
+  };
 
   const renderCompletedGames = () => (
     <div className="row justify-content-center">

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -200,18 +200,18 @@ function UserProfile() {
 
   const renderStatistics = () => (
     <>
-      <div className="row mt-4 justify-content-center">
+      <div className="row mt-5 px-3 justify-content-center">
         {!stats.user.isBot && (
-          <div className="col-md-3 col-5 text-center">
+          <div className="col col-md-3 text-center">
             <div className="h1 cb-stats-number">{stats.user.rank}</div>
             <p className="lead">rank</p>
           </div>
         )}
-        <div className="col-md-3 col-5 text-center">
+        <div className="col col-md-3 text-center">
           <div className="h1 cb-stats-number">{stats.user.rating}</div>
           <p className="lead">elo_rating</p>
         </div>
-        <div className="col-md-3 col-5 text-center">
+        <div className="col col-md-3 text-center">
           <div className="h1 cb-stats-number">
             {Object.values(stats.stats.games).reduce((a, b) => a + b, 0)}
           </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -223,8 +223,8 @@ function UserProfile() {
       >
         {renderCustomPieChart()}
       </div>
-      <div className="row my-4 justify-content-center">
-        <div className="col-10 col-lg-8 cb-heatmap">
+      <div className="row mt-5 mt-md-n3 mb-md-3 mb-lg-4">
+        <div className="col-md-11 col-lg-10 mx-auto">
           <Heatmap />
         </div>
       </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -149,7 +149,7 @@ function UserProfile() {
 
     return (
       <>
-        <div className="col-12 col-md-7">
+        <div className="col-12 col-md-7 mb-sm-n5 mb-md-0">
           <ResponsiveContainer aspect={1}>
             <RadarChart
               cx="50%"
@@ -168,11 +168,11 @@ function UserProfile() {
                 fill="#8884d8"
                 fillOpacity={0.6}
               />
-              <Tooltip />
+              <Tooltip contentStyle={{ padding: '0 10px' }} />
             </RadarChart>
           </ResponsiveContainer>
         </div>
-        <div className="col-10 col-md-5 mt-n5 mt-md-0 pt-md-4">
+        <div className="col-10 col-sm-8 col-md-5 mt-n5 mt-md-0 pt-md-4">
           <ResponsiveContainer aspect={1}>
             <PieChart>
               <Pie

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -260,7 +260,7 @@ function UserProfile() {
     </div>
   );
   const statContainers = () => (
-    <div>
+    <div className="pr-md-2">
       <nav>
         <div className="nav nav-tabs bg-gray" id="nav-tab" role="tablist">
           <a
@@ -309,9 +309,9 @@ function UserProfile() {
   );
 
   return (
-    <div className="container-lg">
-      <div className="row">
-        <div className="col-12 col-md-3 my-4 cb-user-data d-flex flex-column">
+    <div className="row">
+      <div className="col-12 col-md-3 my-4 cb-user-data">
+        <div className="pl-md-2">
           <div className="mb-2 mb-sm-4 d-flex justify-content-center">
             <img
               className="cb-profile-avatar rounded"
@@ -365,9 +365,9 @@ function UserProfile() {
             </div>
           </div>
         </div>
-        <div className="col-12 col-md-9 my-4 cb-user-stats">
-          {statContainers()}
-        </div>
+      </div>
+      <div className="col-12 col-md-9 my-4 cb-user-stats">
+        {statContainers()}
       </div>
     </div>
   );

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -323,7 +323,7 @@ function UserProfile() {
             <h2 className="my-2 text-break cb-heading font-weight-bold">{stats.user.name}</h2>
             <hr />
             <h3 className="my-2 cb-heading">
-              <span className="d-none d-sm-block">Lang:</span>
+              <span>Lang:</span>
               <img
                 src={`/assets/images/achievements/${langIconNames[stats.user.lang]}.png`}
                 alt={stats.user.lang}

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -310,16 +310,16 @@ function UserProfile() {
 
   return (
     <div className="row">
-      <div className="col-12 col-md-3 my-4 cb-user-data">
-        <div className="pl-md-2">
-          <div className="mb-2 mb-sm-4 d-flex justify-content-center">
+      <div className="col-12 col-md-3 my-4">
+        <div className="pl-md-2 text-center">
+          <div className="mb-2 mb-sm-4">
             <img
               className="cb-profile-avatar rounded"
               src={stats.user.avatarUrl}
               alt="User avatar"
             />
           </div>
-          <div className="text-center">
+          <div>
             <h2 className="my-2 text-break cb-heading font-weight-bold">{stats.user.name}</h2>
             <hr />
             <h3 className="my-2 cb-heading">
@@ -366,7 +366,7 @@ function UserProfile() {
           </div>
         </div>
       </div>
-      <div className="col-12 col-md-9 my-4 cb-user-stats">
+      <div className="col-12 col-md-9 my-4">
         {statContainers()}
       </div>
     </div>


### PR DESCRIPTION
Fixes #1495

- диаграммы адаптированы под mobile и их содержимое не выходит за границы своих блоков на ширине вьюпорта от 320px
- доработана разметка страницы профиля юзера и вкладки со статистикой профиля:
  - поправлены отступы на границах страницы от mobile до desktop
  - поправлены отступы между блоками и внутри блоков
  - отрисовка диаграмм убрана если не сыграно ни одной игры
  - индикаторы сыгранных/проигранных/сданных игр переносятся на вторую строчку только если не вмещаются в одну
  - отображение основного языка программирования исправлено на одну строку вместо двух
  - убраны излишне примененные bootstrap стили и кастомные стили, повторяющие стили bootstrap

Исходная задача состояла в адаптации диаграмм, но поскольку их вид зависел в том числе и от окружения, то пришлось доработать разметку всей страницы и сделать ее чуть более eyes-friendly )

| Было | Стало |
|:-:|:-:|
|(1440px)|(1440px)|
|![screencapture-localhost-4000-users-10-2023-09-25-13_42_22](https://github.com/hexlet-codebattle/codebattle/assets/37400913/f7fa347b-09f6-48a8-8164-2743ef868076)|![screencapture-localhost-4000-users-10-2023-09-25-13_27_06](https://github.com/hexlet-codebattle/codebattle/assets/37400913/772b0e80-69ab-4851-bc25-fb70dd123651)|
|(1024px)|(1024px)|
|![screencapture-localhost-4000-users-10-2023-09-25-13_48_26](https://github.com/hexlet-codebattle/codebattle/assets/37400913/1682a04c-a50c-4c59-b6f6-d5d656226bcd)|![screencapture-localhost-4000-users-10-2023-09-25-13_53_13](https://github.com/hexlet-codebattle/codebattle/assets/37400913/c6714f08-2f3c-4223-aacb-32a01fb33ba3)|
|(425px)|(425px)|
|![screencapture-localhost-4000-users-10-2023-09-25-13_41_38](https://github.com/hexlet-codebattle/codebattle/assets/37400913/7faee0be-fca4-49a8-a53f-d6faf230875a)|![screencapture-localhost-4000-users-10-2023-09-25-13_33_25](https://github.com/hexlet-codebattle/codebattle/assets/37400913/236a130f-c23c-45c2-9e8e-7c67f20e96ac)|


