### PR TITLE
[#1590] fix text size in chat form

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
@@ -93,7 +93,7 @@ export default function ChatInput({ inputRef, disabled = false }) {
       onSubmit={handleSubmit}
     >
       <input
-        className="form-control form-control-sm pr-1 h-auto border-gray border-right-0 rounded-left"
+        className="form-control h-auto border-gray border-right-0 rounded-left"
         placeholder="Please be nice in the chat!"
         value={text}
         onChange={handleChange}
@@ -114,7 +114,7 @@ export default function ChatInput({ inputRef, disabled = false }) {
           disabled={disabled}
         />
       )}
-      <div className="input-group-append rounded-right">
+      <div className="input-group-append border-left rounded-right">
         <button
           type="button"
           className="btn bg-white border-gray border-left-0 border-right-0 px-2 py-0"

--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
@@ -94,7 +94,7 @@ export default function ChatInput({ inputRef, disabled = false }) {
     >
       <input
         className="form-control h-auto border-gray border-right-0 rounded-left"
-        placeholder="Please be nice in the chat!"
+        placeholder="Be nice in chat!"
         value={text}
         onChange={handleChange}
         ref={inputRef}

--- a/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/ChatInput.jsx
@@ -93,7 +93,7 @@ export default function ChatInput({ inputRef, disabled = false }) {
       onSubmit={handleSubmit}
     >
       <input
-        className="form-control h-auto border-gray border-right-0 rounded-left"
+        className="form-control form-control-sm pr-1 h-auto border-gray border-right-0 rounded-left"
         placeholder="Please be nice in the chat!"
         value={text}
         onChange={handleChange}
@@ -114,7 +114,7 @@ export default function ChatInput({ inputRef, disabled = false }) {
           disabled={disabled}
         />
       )}
-      <div className="input-group-append border-left rounded-right">
+      <div className="input-group-append rounded-right">
         <button
           type="button"
           className="btn bg-white border-gray border-left-0 border-right-0 px-2 py-0"


### PR DESCRIPTION
Fixes #1590
сделал на бутстрапе без кастомных стилей:

в iphone 12 pro (ширина 390px):
![image](https://github.com/hexlet-codebattle/codebattle/assets/46960223/f1f75079-cc96-4ebe-9772-5dc34231da95)

galaxy S8+ (ширина 360px):
![image](https://github.com/hexlet-codebattle/codebattle/assets/46960223/54a44851-c90a-44c5-8101-fdf3c9cdbb4b)

правда в ширине 320px не влазит слово полностью:
![image](https://github.com/hexlet-codebattle/codebattle/assets/46960223/d9a2f407-6eaf-46c9-ae94-722989dbce0d)

до ширины 350px норм выглядит, есть ли необходимость в правке текста для ширины 320px? 
если нет то можно мержить

если всё же нужно и на 320px, то могу выделить с стилях для этого отдельный кастомный класс
