### PR TITLE
fix frontend tests after axios version bumped

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -79,9 +79,9 @@ jobs:
         run: yarn lint
         working-directory: ./services/app/apps/codebattle
 
-      # - name: Run jest
-        # run: yarn test
-        # working-directory:  ./services/app/apps/codebattle
+      - name: Run jest
+        run: yarn test
+        working-directory:  ./services/app/apps/codebattle
 
       - name: Compile
         run: mix compile

--- a/services/app/apps/codebattle/package.json
+++ b/services/app/apps/codebattle/package.json
@@ -27,7 +27,8 @@
       "^@/pages(.*)$": "<rootDir>/assets/js/widgets/pages$1",
       "^@/selectors(.*)$": "<rootDir>/assets/js/widgets/selectors$1",
       "^@/slices(.*)$": "<rootDir>/assets/js/widgets/slices$1",
-      "^@/utils(.*)$": "<rootDir>/assets/js/widgets/utils$1"
+      "^@/utils(.*)$": "<rootDir>/assets/js/widgets/utils$1",
+      "^axios$": "<rootDir>/node_modules/axios/dist/node/axios.cjs"
     },
     "testPathIgnorePatterns": [
       "/helpers/"


### PR DESCRIPTION
Тесты Jest стали падать после обновления axios до версии >1.0
Вот [здесь](https://github.com/axios/axios/issues/5101) обсуждались варианты решения. Вроде как до сих пор нет идеального и работающего у всех
На мой взгляд лучше бы было начать с обновления Jest до последней версии. Но это вызвало кучу других ошибок в тестах. Пришлось пока отказаться
Данный фикс решает непосредственно проблему изменившегося экспорта axios в новых версиях > 1.0
