### PR TITLE
[#1334] fix charts for multi language users and improve CompletedGames comp 

### DIFF
--- a/services/app/apps/codebattle/assets/css/scrollTable.sass
+++ b/services/app/apps/codebattle/assets/css/scrollTable.sass
@@ -1,8 +1,0 @@
-.table-responsive.scroll
-  overflow-y: scroll
-  max-height: 1000px
-
-  thead
-    position: sticky
-    top: 0
-    background-color: #fff

--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -377,11 +377,6 @@ a {
   overflow: hidden;
 }
 
-.cb-profile {
-  width: 230px;
-  height: auto;
-}
-
 .cb-username {
   font-size: 27px;
 }

--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -20,7 +20,6 @@ $fa-font-path: '/fonts';
 @import '~font-mfizz/dist/font-mfizz.css';
 @import 'tournaments';
 @import 'taskComponent';
-@import 'scrollTable';
 
 em-emoji-picker {
   position: absolute;
@@ -135,6 +134,10 @@ em-emoji-picker {
 
 .basis-0 {
   flex-basis: 0;
+}
+
+.mvh-100 {
+  max-height: 100vh;
 }
 
 .btn {

--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -129,6 +129,14 @@ em-emoji-picker {
   border: 2px solid #d9d9d9;
 }
 
+.min-h-100 {
+  min-height: 100%;
+}
+
+.basis-0 {
+  flex-basis: 0;
+}
+
 .btn {
   border-radius: unset;
 }

--- a/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
@@ -147,7 +147,7 @@ const preloadedState = {
         players,
       },
     ],
-    nextPage: null,
+    currrentPage: null,
     totalPages: null,
   },
   user: {

--- a/services/app/apps/codebattle/assets/js/widgets/components/LanguageIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/LanguageIcon.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import cn from 'classnames';
 
-import { isChrome, isSafari } from '../utils/browser';
-
 const iconsToClass = {
   js: 'icon-nodejs',
   javascript: 'icon-nodejs',
@@ -24,9 +22,7 @@ const iconsToClass = {
 };
 
 const LanguageIcon = ({ lang }) => (
-  <span
-    className={cn('d-flex align-self-end', iconsToClass[lang], { 'mt-2': isChrome() && !isSafari() })}
-  />
+  <span className={cn('d-inline-block', iconsToClass[lang])} style={{ marginTop: 2 }} />
 );
 
 export default LanguageIcon;

--- a/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
@@ -19,7 +19,7 @@ function HorizontalScrollControls({ children }) {
   const [showLeftControl, setShowLeftControl] = useState(false);
   const [showRightControl, setShowRightControl] = useState(children.length > 1);
 
-  const className = 'position-absolute align-items-center h-100 p-2';
+  const className = 'position-absolute align-items-center h-100';
 
   useEffect(() => {
     if (!scrolledListRef.current || scrolledListRef.current.clientWidth === 0) {
@@ -72,7 +72,7 @@ function HorizontalScrollControls({ children }) {
         style={{ left: 0, zIndex: 1000 }}
         className={cn(
           className,
-          'cb-left-scroll-control',
+          'cb-left-scroll-control pr-2',
           {
             'd-flex': showLeftControl,
             'd-none': !showLeftControl,
@@ -81,7 +81,7 @@ function HorizontalScrollControls({ children }) {
       >
         <button
           type="button"
-          className="btn border-0 rounded-circle p-2"
+          className="btn border-0 p-2 h-100"
           onClick={handleScrollItemsLeft}
         >
           <FontAwesomeIcon icon="chevron-left" />
@@ -99,7 +99,7 @@ function HorizontalScrollControls({ children }) {
         style={{ right: 0, zIndex: 1000 }}
         className={cn(
           className,
-          'cb-right-scroll-control',
+          'cb-right-scroll-control pl-2',
           {
             'd-flex': showRightControl,
             'd-none': !showRightControl,
@@ -108,7 +108,7 @@ function HorizontalScrollControls({ children }) {
       >
         <button
           type="button"
-          className="btn border-0 rounded-circle p-2"
+          className="btn border-0 p-2 h-100"
           onClick={handleScrollItemsRight}
         >
           <FontAwesomeIcon

--- a/services/app/apps/codebattle/assets/js/widgets/components/UserName.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/UserName.jsx
@@ -36,7 +36,7 @@ const UserName = ({
   <div className="d-flex align-items-center">
     {!hideOnlineIndicator && renderOnlineIndicator(user, isOnline)}
     <LanguageIcon lang={user.lang || 'js'} />
-    {user.id < 0 && <FontAwesomeIcon className="mx-1 mb-1" icon="robot" />}
+    {user.id < 0 && <FontAwesomeIcon className="mx-1" icon="robot" transform="up-1" />}
     <a
       href={`/users/${user.id}`}
       key={user.id}

--- a/services/app/apps/codebattle/assets/js/widgets/config/fetchionStatuses.js
+++ b/services/app/apps/codebattle/assets/js/widgets/config/fetchionStatuses.js
@@ -1,0 +1,8 @@
+const fetchionStatuses = {
+  idle: 'idle',
+  loading: 'loading',
+  loaded: 'loaded',
+  rejected: 'rejected',
+};
+
+export default fetchionStatuses;

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
@@ -97,7 +97,7 @@ const InfiniteScrollableGames = memo(({ className, tableClassName, games }) => {
           </tbody>
         </table>
       </div>
-      <div ref={cardListRef} className="d-none d-sm-block d-md-none d-flex m-2 overflow-auto position-relative">
+      <div ref={cardListRef} className="d-flex d-md-none my-2 overflow-auto position-relative">
         <HorizontalScrollControls>
           {games.map(game => (
             <GameCard key={`card-${game.id}`} type="completed" game={game} />

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
@@ -111,6 +111,10 @@ function CompletedGames({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [object]);
 
+  if (games.length === 0) {
+    return <div className="my-auto py-5 text-center text-muted">No completed games</div>;
+  }
+
   return (
     <>
       <div

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
@@ -1,9 +1,4 @@
-import React, {
-  memo,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 
 import cn from 'classnames';
 import moment from 'moment';
@@ -20,100 +15,106 @@ import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 
 import GameCard from './GameCard';
 
-const CompletedGamesRows = memo(({ games }) => (
-  <>
-    {games.map(game => (
-      <tr key={game.id}>
-        <td className="p-3 align-middle text-nowrap">
-          <GameLevelBadge level={game.level} />
-        </td>
-        <td className="px-1 py-3 align-middle text-nowrap cb-username-td text-truncate">
-          <div className="d-flex align-items-center">
-            <ResultIcon gameId={game.id} player1={game.players[0]} player2={game.players[1]} />
-            <UserInfo user={game.players[0]} truncate="true" />
-          </div>
-        </td>
-        <td className="px-1 py-3 align-middle text-nowrap cb-username-td text-truncate">
-          <div className="d-flex align-items-center">
-            <ResultIcon gameId={game.id} player1={game.players[1]} player2={game.players[0]} />
-            <UserInfo user={game.players[1]} truncate="true" />
-          </div>
-        </td>
-        <td className="px-1 py-3 align-middle text-nowrap">{moment.utc(game.finishesAt).local().format('MM.DD HH:mm')}</td>
-        <td className="px-1 py-3 align-middle">
-          <a type="button" className="btn btn-secondary btn-sm rounded-lg" href={`/games/${game.id}`}>
-            Show
-          </a>
-        </td>
-      </tr>
-      ))}
-  </>
-));
-
 const commonTableClassName = 'table table-striped mb-0';
 const commonClassName = 'table-responsive d-none d-md-block mvh-100 cb-overflow-y-scroll';
 
+const InfiniteScrollableGames = memo(({ className, tableClassName, games }) => {
+  const dispatch = useDispatch();
+  const tableRef = useRef(null);
+  const cardListRef = useRef(null);
+
+  useEffect(() => {
+    const observableTable = tableRef.current;
+    const observableCards = cardListRef.current;
+
+    const onTableScroll = () => {
+      const height = tableRef.current.scrollHeight - tableRef.current.parentElement?.offsetHeight;
+      const delta = height - tableRef.current.scrollTop;
+
+      if (delta < 500) {
+        dispatch(loadNextPage());
+      }
+    };
+
+    const onCardsScroll = () => {
+      const width = cardListRef.current.scrollWidth - cardListRef.current.parentElement?.offsetWidth;
+      const delta = width - cardListRef.current.scrollLeft;
+
+      if (delta < 50) {
+        dispatch(loadNextPage());
+      }
+    };
+
+    observableTable.addEventListener('scroll', onTableScroll);
+    observableCards.addEventListener('scroll', onCardsScroll);
+
+    return () => {
+      observableTable.removeEventListener('scroll', onTableScroll);
+      observableCards.removeEventListener('scroll', onCardsScroll);
+    };
+  }, [dispatch]);
+
+  return (
+    <>
+      <div ref={tableRef} className={className} data-testid="scroll">
+        <table className={tableClassName}>
+          <thead className="sticky-top bg-white">
+            <tr>
+              <th className="p-3 border-0">Level</th>
+              <th className="px-1 py-3 border-0 text-center" colSpan={2}>Players</th>
+              <th className="px-1 py-3 border-0">Date</th>
+              <th className="px-1 py-3 border-0">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {games.map(game => (
+              <tr key={game.id}>
+                <td className="p-3 align-middle text-nowrap">
+                  <GameLevelBadge level={game.level} />
+                </td>
+                <td className="px-1 py-3 align-middle text-nowrap cb-username-td text-truncate">
+                  <div className="d-flex align-items-center">
+                    <ResultIcon gameId={game.id} player1={game.players[0]} player2={game.players[1]} />
+                    <UserInfo user={game.players[0]} truncate="true" />
+                  </div>
+                </td>
+                <td className="px-1 py-3 align-middle text-nowrap cb-username-td text-truncate">
+                  <div className="d-flex align-items-center">
+                    <ResultIcon gameId={game.id} player1={game.players[1]} player2={game.players[0]} />
+                    <UserInfo user={game.players[1]} truncate="true" />
+                  </div>
+                </td>
+                <td className="px-1 py-3 align-middle text-nowrap">
+                  {moment.utc(game.finishesAt).local().format('MM.DD HH:mm')}
+                </td>
+                <td className="px-1 py-3 align-middle">
+                  <a type="button" className="btn btn-secondary btn-sm rounded-lg" href={`/games/${game.id}`}>
+                    Show
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div ref={cardListRef} className="d-none d-sm-block d-md-none d-flex m-2 overflow-auto position-relative">
+        <HorizontalScrollControls>
+          {games.map(game => (
+            <GameCard key={`card-${game.id}`} type="completed" game={game} />
+          ))}
+        </HorizontalScrollControls>
+      </div>
+    </>
+  );
+});
+
 function CompletedGames({ className, tableClassName = '' }) {
   const dispatch = useDispatch();
-
-  const {
-    completedGames, nextPage, totalPages, totalGames, status,
-  } = useSelector(completedGamesSelector);
-  const object = useMemo(
-    () => ({ loading: false }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [nextPage],
-  );
+  const { completedGames, totalGames, status } = useSelector(completedGamesSelector);
 
   useEffect(() => {
     dispatch(fetchCompletedGames());
   }, [dispatch]);
-
-  /** @type {import("react").RefObject<HTMLDivElement>} */
-  const cardListRef = useRef(null);
-  const tableRef = useRef(null);
-
-  useEffect(() => {
-    const observerTableRef = tableRef;
-    const observerCardsRef = cardListRef;
-
-    const load = () => {
-      if (object.loading) return;
-      object.loading = true;
-
-      if (nextPage <= totalPages) dispatch(loadNextPage(nextPage));
-    };
-
-    const onCardsScroll = () => {
-      if (!cardListRef.current) return;
-      const width = cardListRef.current.scrollWidth - cardListRef.current.parentElement?.offsetWidth;
-      const delta = width - cardListRef.current.scrollLeft;
-
-      if (delta < 50) { load(); }
-    };
-
-    const onTableScroll = () => {
-      if (!tableRef.current) return;
-      const height = tableRef.current.scrollHeight - tableRef.current.parentElement?.offsetHeight;
-      const delta = height - tableRef.current.scrollTop;
-
-      if (delta < 500) { load(); }
-    };
-
-    observerTableRef.current?.addEventListener('scroll', onTableScroll);
-    observerCardsRef.current?.addEventListener('scroll', onCardsScroll);
-
-    return () => {
-      if (observerTableRef) {
-        observerTableRef.current?.removeEventListener('scroll', onTableScroll);
-      }
-
-      if (observerCardsRef) {
-        observerCardsRef.current?.removeEventListener('scroll', onCardsScroll);
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [object]);
 
   if (completedGames.length === 0) {
     return status === fetchionStatuses.loading
@@ -123,40 +124,11 @@ function CompletedGames({ className, tableClassName = '' }) {
 
   return (
     <>
-      <div
-        ref={tableRef}
+      <InfiniteScrollableGames
         className={cn(commonClassName, className)}
-        data-testid="scroll"
-      >
-        <table
-          className={cn(commonTableClassName, tableClassName)}
-        >
-          <thead className="sticky-top bg-white">
-            <tr>
-              <th className="p-3 border-0">Level</th>
-              <th className="px-1 py-3 border-0 text-center" colSpan={2}>
-                Players
-              </th>
-              <th className="px-1 py-3 border-0">Date</th>
-              <th className="px-1 py-3 border-0">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <CompletedGamesRows games={completedGames} />
-          </tbody>
-        </table>
-      </div>
-      <div ref={cardListRef} className="d-none d-sm-block d-md-none d-flex m-2 overflow-auto position-relative">
-        <HorizontalScrollControls>
-          {completedGames.map(game => (
-            <GameCard
-              key={`card-${game.id}`}
-              type="completed"
-              game={game}
-            />
-          ))}
-        </HorizontalScrollControls>
-      </div>
+        tableClassName={cn(commonTableClassName, tableClassName)}
+        games={completedGames}
+      />
       <div className="mt-auto border-top py-2 px-5 font-weight-bold bg-white">
         {`Total games: ${totalGames}`}
       </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
@@ -179,7 +179,7 @@ const CompletedTournaments = ({ tournaments }) => {
   return (
     <div className="table-responsive">
       <h2 className="text-center mt-3">Completed tournaments</h2>
-      <div className="d-none d-sm-none d-md-block table-responsive rounded-bottom">
+      <div className="d-none d-md-block table-responsive rounded-bottom">
         <table className="table table-striped">
           <thead className="">
             <tr>
@@ -212,7 +212,7 @@ const CompletedTournaments = ({ tournaments }) => {
           </tbody>
         </table>
       </div>
-      <div className="d-none d-sm-block d-md-none d-flex m-2 overflow-auto position-relative">
+      <div className="d-flex d-md-none m-2 overflow-auto position-relative">
         <HorizontalScrollControls>
           {sortedTournaments.map(
             tournament => (
@@ -277,7 +277,7 @@ const ActiveGames = ({
 
   return (
     <>
-      <div className="d-none d-sm-none d-md-block table-responsive rounded-bottom">
+      <div className="d-none d-md-block table-responsive rounded-bottom">
         <table className="table table-striped mb-0">
           <thead className="text-center">
             <tr>
@@ -320,7 +320,7 @@ const ActiveGames = ({
         </table>
       </div>
       <div
-        className="d-none d-sm-block d-md-none d-flex m-2 position-relative"
+        className="d-flex d-md-none m-2 position-relative"
       >
         <HorizontalScrollControls>
           {sortedGames.map(

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
@@ -28,7 +28,6 @@ import levelRatio from '../../config/levelRatio';
 import * as lobbyMiddlewares from '../../middlewares/Lobby';
 import * as selectors from '../../selectors';
 import { actions } from '../../slices';
-import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 import { getLobbyUrl, makeGameUrl } from '../../utils/urlBuilders';
 
 import Announcement from './Announcement';
@@ -366,10 +365,8 @@ const tabLinkHandler = hash => () => {
 
 const GameContainers = ({
   activeGames,
-  completedGames,
   liveTournaments,
   completedTournaments,
-  totalGames,
   currentUserId,
   isGuest = true,
   isOnline = false,
@@ -462,13 +459,7 @@ const GameContainers = ({
           role="tabpanel"
           aria-labelledby="completedGames-tab"
         >
-          <CompletedGames
-            type="completed"
-            className="table-responsive scroll cb-lobby-widget-container"
-            games={completedGames}
-            loadNextPage={loadNextPage}
-            totalGames={totalGames}
-          />
+          <CompletedGames className="cb-lobby-widget-container" />
         </div>
       </div>
     </div>
@@ -507,7 +498,6 @@ const LobbyWidget = () => {
   const currentUserId = useSelector(selectors.currentUserIdSelector);
   const isGuest = useSelector(selectors.currentUserIsGuestSelector);
   const isModalShow = useSelector(selectors.isModalShow);
-  const { completedGames, totalGames } = useSelector(selectors.completedGamesData);
   const activeGame = useSelector(selectors.activeGameSelector);
   const {
     activeGames,
@@ -545,10 +535,6 @@ const LobbyWidget = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    dispatch(fetchCompletedGames());
-  }, [dispatch]);
-
   return (
     <div className="container-lg">
       {renderModal(isModalShow, handleCloseModal)}
@@ -565,10 +551,8 @@ const LobbyWidget = () => {
           </div>
           <GameContainers
             activeGames={activeGames}
-            completedGames={completedGames}
             liveTournaments={liveTournaments}
             completedTournaments={completedTournaments}
-            totalGames={totalGames}
             currentUserId={currentUserId}
             isGuest={isGuest}
             isOnline={online}

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/Achievement.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/Achievement.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+function Achievement({ achievement }) {
+  if (!achievement.includes('win_games_with')) {
+    return (
+      <img
+        className="mr-1 mb-1"
+        src={`/assets/images/achievements/${achievement}.png`}
+        alt={achievement}
+        title={achievement}
+        width="65"
+        height="65"
+      />
+    );
+  }
+
+  const langs = achievement.split('?').pop().split('_');
+
+  return (
+    <div className="cb-polyglot mr-1 mb-1" title={achievement}>
+      <div className="cb-polyglot-icons d-flex flex-wrap align-items-center justify-content-around h-75">
+        {langs.map(lang => (
+          <img
+            src={`/assets/images/achievements/${lang}.png`}
+            alt={lang}
+            title={lang}
+            width="14"
+            height="14"
+            key={lang}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Achievement;

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -4,13 +4,11 @@ import axios from 'axios';
 import cn from 'classnames';
 import { camelizeKeys } from 'humps';
 import sum from 'lodash/sum';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import Loading from '../../components/Loading';
 import langIconNames from '../../config/langIconNames';
-import * as selectors from '../../selectors';
 import { actions } from '../../slices';
-import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 import CompletedGames from '../lobby/CompletedGames';
 
 import Achievement from './Achievement';
@@ -19,7 +17,6 @@ import UserStatCharts from './UserStatCharts';
 
 function UserProfile() {
   const [userData, setUserData] = useState(null);
-  const { completedGames, totalGames } = useSelector(selectors.completedGamesData);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -33,10 +30,6 @@ function UserProfile() {
       .catch(error => {
         dispatch(actions.setError(error));
       });
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchCompletedGames());
   }, [dispatch]);
 
   if (!userData) {
@@ -164,13 +157,8 @@ function UserProfile() {
               role="tabpanel"
               aria-labelledby="completedGames-tab"
             >
-              <div className="h-100 d-flex flex-column">
-                <CompletedGames
-                  className="table-responsive scroll h-75"
-                  games={completedGames}
-                  loadNextPage={loadNextPage}
-                  totalGames={totalGames}
-                />
+              <div className="h-100 d-flex flex-column justify-content-center">
+                <CompletedGames className="h-100" />
               </div>
             </div>
           </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -13,6 +13,7 @@ import { actions } from '../../slices';
 import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 import CompletedGames from '../lobby/CompletedGames';
 
+import Achievement from './Achievement';
 import Heatmap from './Heatmap';
 import UserStatCharts from './UserStatCharts';
 
@@ -38,50 +39,16 @@ function UserProfile() {
     dispatch(fetchCompletedGames());
   }, [dispatch]);
 
-  const dateParse = date => new Date(date).toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
-  const renderAchivement = achievement => {
-    if (achievement.includes('win_games_with')) {
-      const langs = achievement.split('?').pop().split('_');
-
-      return (
-        <div className="cb-polyglot mr-1 mb-1" title={achievement}>
-          <div className="d-flex h-75 flex-wrap align-items-center justify-content-around cb-polyglot-icons">
-            {langs.map(lang => (
-              <img
-                src={`/assets/images/achievements/${lang}.png`}
-                alt={lang}
-                title={lang}
-                width="14"
-                height="14"
-                key={lang}
-              />
-            ))}
-          </div>
-        </div>
-      );
-    }
-    return (
-      <img
-        className="mr-1 mb-1"
-        src={`/assets/images/achievements/${achievement}.png`}
-        alt={achievement}
-        title={achievement}
-        width="65"
-        height="65"
-      />
-    );
-  };
-
   if (!userData) {
     return <Loading />;
   }
 
   const { stats, user } = userData;
+  const userInsertedAt = new Date(user.insertedAt).toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
   const gamesCount = sum(Object.values(stats.games));
 
   const renderCompletedGames = () => (
@@ -125,9 +92,9 @@ function UserProfile() {
             />
           </div>
           <div>
-            <h2 className="my-2 text-break cb-heading font-weight-bold">{user.name}</h2>
+            <h1 className="cb-heading text-break font-weight-bold">{user.name}</h1>
             <hr />
-            <h3 className="my-2 cb-heading">
+            <h3 className="cb-heading">
               <span>Lang:</span>
               <img
                 src={`/assets/images/achievements/${langIconNames[user.lang]}.png`}
@@ -138,12 +105,9 @@ function UserProfile() {
               />
             </h3>
             <hr />
-            <p className="small text-monospace text-muted mb-2">
-              {'joined at '}
-              {dateParse(user.insertedAt)}
-            </p>
-            <h1 className="my-2">
-              {user.githubName && (
+            <p className="mb-2 small text-monospace text-muted">{`joined at ${userInsertedAt}`}</p>
+            {user.githubName && (
+              <h3 className="h1">
                 <a
                   title="Github account"
                   className="text-muted"
@@ -151,23 +115,17 @@ function UserProfile() {
                 >
                   <span className="fab fa-github" />
                 </a>
-              )}
-            </h1>
-            <div className="my-2">
-              {user.achievements.length > 0 && (
-                <>
-                  <hr className="mt-2" />
-                  <h5 className="text-break cb-heading">Achievements</h5>
-                  <div className="col d-flex flex-wrap justify-content-start cb-profile mt-3 pl-0">
-                    {user.achievements.map(achievement => (
-                      <div key={achievement}>
-                        {renderAchivement(achievement)}
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
-            </div>
+              </h3>
+            )}
+            {user.achievements.length > 0 && (
+              <>
+                <hr className="mt-2" />
+                <h3 className="text-break cb-heading">Achievements</h3>
+                <div className="d-flex flex-wrap justify-content-start mt-3">
+                  {user.achievements.map(item => <Achievement key={item} achievement={item} />)}
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -3,23 +3,8 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import cn from 'classnames';
 import { camelizeKeys } from 'humps';
-import groupBy from 'lodash/groupBy';
-import mapValues from 'lodash/mapValues';
 import sum from 'lodash/sum';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  Radar,
-  RadarChart,
-  PolarGrid,
-  PolarAngleAxis,
-  PolarRadiusAxis,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  Legend,
-} from 'recharts';
 
 import Loading from '../../components/Loading';
 import langIconNames from '../../config/langIconNames';
@@ -29,13 +14,11 @@ import { fetchCompletedGames, loadNextPage } from '../../slices/completedGames';
 import CompletedGames from '../lobby/CompletedGames';
 
 import Heatmap from './Heatmap';
+import UserStatCharts from './UserStatCharts';
 
 function UserProfile() {
-  const [stats, setStats] = useState(null);
-  const { completedGames, totalGames } = useSelector(
-    selectors.completedGamesData,
-  );
-
+  const [userData, setUserData] = useState(null);
+  const { completedGames, totalGames } = useSelector(selectors.completedGamesData);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -44,7 +27,7 @@ function UserProfile() {
     axios
       .get(`/api/v1/user/${userId}/stats`)
       .then(response => {
-        setStats(camelizeKeys(response.data));
+        setUserData(camelizeKeys(response.data));
       })
       .catch(error => {
         dispatch(actions.setError(error));
@@ -94,146 +77,12 @@ function UserProfile() {
     );
   };
 
-  if (!stats) {
+  if (!userData) {
     return <Loading />;
   }
 
-  const renderCustomPieChart = () => {
-    if (!stats.stats) {
-      return <Loading />;
-    }
-
-    const colors = [
-      '#8884d8',
-      '#0000FF',
-      '#008000',
-      '#FF0000',
-      '#800080',
-      '#FFA500',
-      '#FFC0CB',
-      '#A52A2A',
-      '#808080',
-      '#ADD8E6',
-      '#90EE90',
-      '#FFB6C1',
-      '#E6E6FA',
-      '#FFA07A',
-    ];
-
-    const groups = groupBy(stats.stats.all, 'lang');
-    const reducedByLangStats = mapValues(groups, group => group.reduce((total, item) => total + item.count, 0));
-    const resultDataForPie = Object.entries(reducedByLangStats).map(
-      ([lang, count]) => ({ name: lang, value: count }),
-    );
-    const fullMark = Math.max(...Object.values(stats.stats.games));
-    const resultDataForRadar = Object.keys(stats.stats.games).map(
-      subject => ({
-        subject,
-        A: stats.stats.games[subject],
-        fullMark,
-      }),
-    );
-
-    const sortedDataForPie = resultDataForPie.sort(
-      ({ value: a }, { value: b }) => {
-        if (a < b) return 1;
-        if (a > b) return -1;
-        return 0;
-      },
-    );
-    const sortedDataForRadar = resultDataForRadar.sort((a, b) => {
-      if (a.subject === 'won') return -1;
-      if (b.subject === 'won') return 1;
-      if (a.subject < b.subject) return -1;
-      if (a.subject > b.subject) return 1;
-      return 0;
-    });
-
-    return (
-      <>
-        <div className="col-12 col-md-7 mb-sm-n5 mb-md-0">
-          <ResponsiveContainer aspect={1}>
-            <RadarChart
-              cx="50%"
-              cy="50%"
-              outerRadius="70%"
-              margin={{ right: 70 }}
-              data={sortedDataForRadar}
-            >
-              <PolarGrid />
-              <PolarAngleAxis dataKey="subject" />
-              <PolarRadiusAxis />
-              <Radar
-                name="count"
-                dataKey="A"
-                stroke="#8884d8"
-                fill="#8884d8"
-                fillOpacity={0.6}
-              />
-              <Tooltip contentStyle={{ padding: '0 10px' }} />
-            </RadarChart>
-          </ResponsiveContainer>
-        </div>
-        <div className="col-10 col-sm-8 col-md-5 mt-n5 mt-md-0 pt-md-4">
-          <ResponsiveContainer aspect={1}>
-            <PieChart>
-              <Pie
-                dataKey="value"
-                data={sortedDataForPie}
-                labelLine={false}
-                label
-                position="inside"
-              >
-                {sortedDataForPie.map(({ name }, index) => (
-                  <Cell
-                    key={`cell-${name}`}
-                    fill={colors[index % colors.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip />
-              <Legend />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </>
-    );
-  };
-
-  const renderStatistics = () => {
-    const gamesCount = sum(Object.values(stats.stats.games));
-
-    return (
-      <>
-        <div className="row mt-5 px-3 justify-content-center">
-          {!stats.user.isBot && (
-            <div className="col col-md-3 text-center">
-              <div className="h1 cb-stats-number">{stats.user.rank}</div>
-              <p className="lead">rank</p>
-            </div>
-          )}
-          <div className="col col-md-3 text-center">
-            <div className="h1 cb-stats-number">{stats.user.rating}</div>
-            <p className="lead">elo_rating</p>
-          </div>
-          <div className="col col-md-3 text-center">
-            <div className="h1 cb-stats-number">
-              {gamesCount}
-            </div>
-            <p className="lead">games_played</p>
-          </div>
-        </div>
-        <div className="row justify-content-center">
-          {gamesCount > 0 && renderCustomPieChart()}
-        </div>
-        <div className={cn('row mt-5 mb-md-3 mb-lg-4', { 'mt-md-n3': gamesCount > 0 })}>
-          <div className="col-md-11 col-lg-10 mx-auto">
-            <Heatmap />
-          </div>
-        </div>
-      </>
-    );
-  };
+  const { stats, user } = userData;
+  const gamesCount = sum(Object.values(stats.games));
 
   const renderCompletedGames = () => (
     <div className="row justify-content-center">
@@ -263,54 +112,6 @@ function UserProfile() {
       </div>
     </div>
   );
-  const statContainers = () => (
-    <div className="pr-md-2">
-      <nav>
-        <div className="nav nav-tabs bg-gray" id="nav-tab" role="tablist">
-          <a
-            className="nav-item nav-link active text-uppercase rounded-0 text-black font-weight-bold p-3"
-            id="statistics-tab"
-            data-toggle="tab"
-            href="#statistics"
-            role="tab"
-            aria-controls="statistics"
-            aria-selected="true"
-          >
-            Statistics
-          </a>
-          <a
-            className="nav-item nav-link text-uppercase rounded-0 text-black font-weight-bold p-3"
-            id="completedGames-tab"
-            data-toggle="tab"
-            href="#completedGames"
-            role="tab"
-            aria-controls="completedGames"
-            aria-selected="false"
-          >
-            Completed games
-          </a>
-        </div>
-      </nav>
-      <div className="tab-content" id="nav-tabContent">
-        <div
-          className="tab-pane fade border show active"
-          id="statistics"
-          role="tabpanel"
-          aria-labelledby="statistics-tab"
-        >
-          {renderStatistics()}
-        </div>
-        <div
-          className="tab-pane fade"
-          id="completedGames"
-          role="tabpanel"
-          aria-labelledby="completedGames-tab"
-        >
-          {renderCompletedGames()}
-        </div>
-      </div>
-    </div>
-  );
 
   return (
     <div className="row">
@@ -319,19 +120,19 @@ function UserProfile() {
           <div className="mb-2 mb-sm-4">
             <img
               className="cb-profile-avatar rounded"
-              src={stats.user.avatarUrl}
+              src={user.avatarUrl}
               alt="User avatar"
             />
           </div>
           <div>
-            <h2 className="my-2 text-break cb-heading font-weight-bold">{stats.user.name}</h2>
+            <h2 className="my-2 text-break cb-heading font-weight-bold">{user.name}</h2>
             <hr />
             <h3 className="my-2 cb-heading">
               <span>Lang:</span>
               <img
-                src={`/assets/images/achievements/${langIconNames[stats.user.lang]}.png`}
-                alt={stats.user.lang}
-                title={stats.user.lang}
+                src={`/assets/images/achievements/${langIconNames[user.lang]}.png`}
+                alt={user.lang}
+                title={user.lang}
                 width="30"
                 height="30"
               />
@@ -339,26 +140,26 @@ function UserProfile() {
             <hr />
             <p className="small text-monospace text-muted mb-2">
               {'joined at '}
-              {dateParse(stats.user.insertedAt)}
+              {dateParse(user.insertedAt)}
             </p>
             <h1 className="my-2">
-              {stats.user.githubName && (
+              {user.githubName && (
                 <a
                   title="Github account"
                   className="text-muted"
-                  href={`https://github.com/${stats.user.githubName}`}
+                  href={`https://github.com/${user.githubName}`}
                 >
                   <span className="fab fa-github" />
                 </a>
               )}
             </h1>
             <div className="my-2">
-              {stats.user.achievements.length > 0 && (
+              {user.achievements.length > 0 && (
                 <>
                   <hr className="mt-2" />
                   <h5 className="text-break cb-heading">Achievements</h5>
                   <div className="col d-flex flex-wrap justify-content-start cb-profile mt-3 pl-0">
-                    {stats.user.achievements.map(achievement => (
+                    {user.achievements.map(achievement => (
                       <div key={achievement}>
                         {renderAchivement(achievement)}
                       </div>
@@ -371,7 +172,73 @@ function UserProfile() {
         </div>
       </div>
       <div className="col-12 col-md-9 my-4">
-        {statContainers()}
+        <div className="pr-md-2">
+          <nav>
+            <div className="nav nav-tabs bg-gray" id="nav-tab" role="tablist">
+              <a
+                className="nav-item nav-link active text-uppercase rounded-0 text-black font-weight-bold p-3"
+                id="statistics-tab"
+                data-toggle="tab"
+                href="#statistics"
+                role="tab"
+                aria-controls="statistics"
+                aria-selected="true"
+              >
+                Statistics
+              </a>
+              <a
+                className="nav-item nav-link text-uppercase rounded-0 text-black font-weight-bold p-3"
+                id="completedGames-tab"
+                data-toggle="tab"
+                href="#completedGames"
+                role="tab"
+                aria-controls="completedGames"
+                aria-selected="false"
+              >
+                Completed games
+              </a>
+            </div>
+          </nav>
+          <div className="tab-content" id="nav-tabContent">
+            <div
+              className="tab-pane fade border show active"
+              id="statistics"
+              role="tabpanel"
+              aria-labelledby="statistics-tab"
+            >
+              <div className="row mt-5 px-3 justify-content-center">
+                {!user.isBot && (
+                  <div className="col col-md-3 text-center">
+                    <div className="h1 cb-stats-number">{user.rank}</div>
+                    <p className="lead">rank</p>
+                  </div>
+                )}
+                <div className="col col-md-3 text-center">
+                  <div className="h1 cb-stats-number">{user.rating}</div>
+                  <p className="lead">elo_rating</p>
+                </div>
+                <div className="col col-md-3 text-center">
+                  <div className="h1 cb-stats-number">{gamesCount}</div>
+                  <p className="lead">games_played</p>
+                </div>
+              </div>
+              {gamesCount > 0 && <UserStatCharts stats={stats} />}
+              <div className={cn('row mt-5 mb-md-3 mb-lg-4', { 'mt-lg-0': gamesCount > 0 })}>
+                <div className="col-md-11 col-lg-10 mx-auto">
+                  <Heatmap />
+                </div>
+              </div>
+            </div>
+            <div
+              className="tab-pane fade"
+              id="completedGames"
+              role="tabpanel"
+              aria-labelledby="completedGames-tab"
+            >
+              {renderCompletedGames()}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserProfile.jsx
@@ -51,35 +51,6 @@ function UserProfile() {
   });
   const gamesCount = sum(Object.values(stats.games));
 
-  const renderCompletedGames = () => (
-    <div className="row justify-content-center">
-      <div className="col-12">
-        <div className="text-left">
-          {completedGames && completedGames.length > 0 && (
-            <>
-              <CompletedGames
-                className="table-responsive scroll h-75"
-                games={completedGames}
-                loadNextPage={loadNextPage}
-                totalGames={totalGames}
-              />
-            </>
-          )}
-          {completedGames && completedGames.length === 0 && (
-            <>
-              <div
-                style={{ height: 498 }}
-                className="d-flex align-items-center justify-content-center border text-muted"
-              >
-                No completed games
-              </div>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-
   return (
     <div className="row">
       <div className="col-12 col-md-3 my-4">
@@ -130,7 +101,7 @@ function UserProfile() {
         </div>
       </div>
       <div className="col-12 col-md-9 my-4">
-        <div className="pr-md-2">
+        <div className="pr-md-2 min-h-100 d-flex flex-column">
           <nav>
             <div className="nav nav-tabs bg-gray" id="nav-tab" role="tablist">
               <a
@@ -157,9 +128,9 @@ function UserProfile() {
               </a>
             </div>
           </nav>
-          <div className="tab-content" id="nav-tabContent">
+          <div className="tab-content border border-top-0 flex-grow-1 basis-0" id="nav-tabContent">
             <div
-              className="tab-pane fade border show active"
+              className="tab-pane fade show active"
               id="statistics"
               role="tabpanel"
               aria-labelledby="statistics-tab"
@@ -188,12 +159,19 @@ function UserProfile() {
               </div>
             </div>
             <div
-              className="tab-pane fade"
+              className="tab-pane fade min-h-100"
               id="completedGames"
               role="tabpanel"
               aria-labelledby="completedGames-tab"
             >
-              {renderCompletedGames()}
+              <div className="h-100 d-flex flex-column">
+                <CompletedGames
+                  className="table-responsive scroll h-75"
+                  games={completedGames}
+                  loadNextPage={loadNextPage}
+                  totalGames={totalGames}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserStatCharts.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/profile/UserStatCharts.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import groupBy from 'lodash/groupBy';
+import sumBy from 'lodash/sumBy';
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from 'recharts';
+
+const colors = [
+  '#8884d8',
+  '#0000FF',
+  '#008000',
+  '#FF0000',
+  '#800080',
+  '#FFA500',
+  '#FFC0CB',
+  '#A52A2A',
+  '#808080',
+  '#ADD8E6',
+  '#90EE90',
+  '#FFB6C1',
+  '#E6E6FA',
+  '#FFA07A',
+];
+
+function UserStatCharts({ stats }) {
+  const statByLang = groupBy(stats.all, 'lang');
+  const resultDataForPie = Object.entries(statByLang)
+    .map(([lang, gameStats]) => ({
+      name: lang,
+      value: sumBy(gameStats, 'count'),
+    }))
+    .sort(({ value: a }, { value: b }) => {
+      if (a < b) return 1;
+      if (a > b) return -1;
+      return 0;
+    });
+
+  const fullMark = Math.max(...Object.values(stats.games));
+  const resultDataForRadar = Object.keys(stats.games)
+    .map(subject => ({
+      subject,
+      A: stats.games[subject],
+      fullMark,
+    }))
+    .sort((a, b) => {
+      if (a.subject === 'won') return -1;
+      if (b.subject === 'won') return 1;
+      if (a.subject < b.subject) return -1;
+      if (a.subject > b.subject) return 1;
+      return 0;
+    });
+
+  return (
+    <div className="row justify-content-center pb-4">
+      <div className="col-12 col-lg-7 mb-sm-n5 mb-lg-0">
+        <ResponsiveContainer aspect={1}>
+          <RadarChart
+            cx="50%"
+            cy="50%"
+            outerRadius="70%"
+            margin={{ right: 70 }}
+            data={resultDataForRadar}
+          >
+            <PolarGrid />
+            <PolarAngleAxis dataKey="subject" />
+            <PolarRadiusAxis />
+            <Radar
+              name="count"
+              dataKey="A"
+              stroke="#8884d8"
+              fill="#8884d8"
+              fillOpacity={0.6}
+            />
+            <Tooltip contentStyle={{ padding: '0 10px' }} />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="col-12 col-sm-8 col-md-10 col-lg-5 mt-n5 mt-lg-0 pt-lg-3">
+        <ResponsiveContainer aspect={0.8}>
+          <PieChart>
+            <Pie
+              outerRadius="70%"
+              dataKey="value"
+              data={resultDataForPie}
+              labelLine={false}
+              label
+              position="inside"
+            >
+              {resultDataForPie.map(({ name }, index) => (
+                <Cell key={`cell-${name}`} fill={colors[index % colors.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export default UserStatCharts;

--- a/services/app/apps/codebattle/assets/js/widgets/selectors/index.js
+++ b/services/app/apps/codebattle/assets/js/widgets/selectors/index.js
@@ -377,7 +377,7 @@ export const isModalShow = state => state.lobby.createGameModal.show;
 
 export const modalSelector = state => state.lobby.createGameModal;
 
-export const completedGamesData = state => state.completedGames;
+export const completedGamesSelector = state => state.completedGames;
 
 export const activeRoomSelector = state => state.chat.activeRoom;
 

--- a/services/app/apps/codebattle/assets/js/widgets/slices/completedGames.js
+++ b/services/app/apps/codebattle/assets/js/widgets/slices/completedGames.js
@@ -3,6 +3,8 @@ import axios from 'axios';
 import { camelizeKeys } from 'humps';
 import unionBy from 'lodash/unionBy';
 
+import fetchionStatuses from '../config/fetchionStatuses';
+
 import initial from './initial';
 import { actions as lobbyActions } from './lobby';
 
@@ -41,37 +43,37 @@ const completedGames = createSlice({
     nextPage: null,
     totalPages: null,
     totalGames: 0,
-    status: 'empty',
+    status: fetchionStatuses.idle,
     error: null,
   },
   reducers: {},
   extraReducers: {
     [fetchCompletedGames.pending]: state => {
-      state.status = 'loading';
+      state.status = fetchionStatuses.loading;
       state.error = null;
     },
     [fetchCompletedGames.fulfilled]: (state, { payload }) => {
-      state.status = 'loaded';
+      state.status = fetchionStatuses.loaded;
       state.completedGames = payload.games;
       state.totalPages = payload.pageInfo.totalPages;
       state.nextPage = payload.pageInfo.pageNumber + 1;
       state.totalGames = payload.pageInfo.totalEntries;
     },
     [fetchCompletedGames.rejected]: (state, action) => {
-      state.status = 'rejected';
+      state.status = fetchionStatuses.rejected;
       state.error = action.error;
     },
     [loadNextPage.pending]: state => {
-      state.status = 'loading';
+      state.status = fetchionStatuses.loading;
       state.error = null;
     },
     [loadNextPage.fulfilled]: (state, { payload }) => {
-      state.status = 'loaded';
+      state.status = fetchionStatuses.loaded;
       state.nextPage += 1;
       state.completedGames = unionBy(state.completedGames, payload.games, 'id');
     },
     [loadNextPage.rejected]: (state, action) => {
-      state.status = 'rejected';
+      state.status = fetchionStatuses.rejected;
       state.error = action.error;
     },
     [lobbyActions.finishGame]: (state, { payload: { game } }) => {


### PR DESCRIPTION
Fixes #1334, #1303

Доработан компонет UserProfile с учетом статистики ботов и игроков-"мультиязычников".

<details>
<summary>Скриншоты</summary>

  Было

  | 320px | 768px | 1024px |
  |:-:|:-:|:-:|
  |![screencapture-localhost-4000-users-10-2023-12-12-16_14_14](https://github.com/hexlet-codebattle/codebattle/assets/37400913/97e2cfca-f4dc-4a02-a84e-0d813416dfd3)|![screencapture-localhost-4000-users-10-2023-12-12-16_13_11](https://github.com/hexlet-codebattle/codebattle/assets/37400913/0fe25b8a-3933-4884-b1b6-4bcc513eb819)|![screencapture-localhost-4000-users-10-2023-12-12-16_12_50](https://github.com/hexlet-codebattle/codebattle/assets/37400913/4753f115-0c4c-434c-8e72-177220a7725c)|

  Стало

| 320px | 768px | 1024px |
|:-:|:-:|:-:|
|![screencapture-localhost-4000-users-21-2023-10-29-11_04_33](https://github.com/hexlet-codebattle/codebattle/assets/37400913/1e89e3d8-78e5-46cc-bc12-68cbd9db8067)|![screencapture-localhost-4000-users-21-2023-10-29-11_09_11](https://github.com/hexlet-codebattle/codebattle/assets/37400913/6f294ee0-ac33-406e-bd65-369a607cfdfd)|![screencapture-localhost-4000-users-21-2023-10-29-11_10_11](https://github.com/hexlet-codebattle/codebattle/assets/37400913/bfe35b59-6b42-4d2e-a506-2afe93252fea)|
</details>

Пояснения по сопутствующим доработкам
  - выделены отдельные компоненты для достижений и диаграмм статистики для облегчения кода `UserProfile`
  - улучшено отображение списка завершенных игр. Высота таблицы не "захардкожена", а сделана "резиновой" независимо от ширины экрана и наличия игр
    <details>
      <summary>Скриншоты</summary>
      
      | Было | Стало |
      |:-:|:-:|
      | mobile | mobile |
      |![screencapture-localhost-4000-users-3-2023-12-12-13_43_09](https://github.com/hexlet-codebattle/codebattle/assets/37400913/da6fd3b8-4d1e-43e3-9733-a281f15d6e5a)|![screencapture-localhost-4000-users-3-2023-12-12-17_27_24](https://github.com/hexlet-codebattle/codebattle/assets/37400913/d6bbd2ba-1a1f-424c-a793-6746f73274ee)|
      | desktop | desktop |
      |![screencapture-localhost-4000-users-3-2023-12-12-13_44_14](https://github.com/hexlet-codebattle/codebattle/assets/37400913/59728a0b-3212-49f2-83ea-d334aa64b157)|![screencapture-localhost-4000-users-3-2023-12-12-17_27_03](https://github.com/hexlet-codebattle/codebattle/assets/37400913/ec931bcc-85b8-4245-93a9-d0f43714e9ff)|
    </details>
  -  сам компонент `CompletedGames` немного доработан - меньше пропсов перекидывается между компонентов, меньше данных из стора запрашивается
      - обработка для пустого списка перенесена из вызывающего кода в компонент
      - данные из сети/стора берёт сам
      - реализация бесконечного скролла упрощена, благодаря переносу логики в асинхронный экшен `loadNextPage` 
  - кастомный класс `table-responsive.scroll` заменён стандартными BS классами-утилитами, свойство `max-height: 1000px` заменено на кастомный класс `mvh-100`, с сопоставимым значением высоты и который выглядит более 'bootstrap-way'
  - добавленные кастомные классы не содержат `cb-` префикса, потому что это классы-утилиты и не специфичны для Кодбатла. Рано или поздно Bootstrap будет мигрирован до 5 версии, и эти утилиты будут сгенерированы через API утилит без необходимости править их использование в коде
  - исправлен баг горизонтальной прокрутки, заключающийся в переносе правой кнопки прокрутки вниз за пределы блока. Кнопки прокрутки увеличены на всю высоту блока для удобства использования
    <details>
      <summary>Скриншоты</summary>
      
      | Было | Стало |
      |:-:|:-:|
      |![Screenshot from 2023-12-12 18-06-02](https://github.com/hexlet-codebattle/codebattle/assets/37400913/6fa2aaf1-189a-46a9-8723-5748c14fc29a)|![Screenshot from 2023-12-12 13-27-35](https://github.com/hexlet-codebattle/codebattle/assets/37400913/07ea868a-5b58-449c-86e6-38225e5d96fa)|
    </details>
  - выровнены иконки языка/онлайн/робота. Проверено и в остальных компонентах проекта в Chrome/Firefox. В Safari, к сожалению, нет возможности проверить

    <details>
      <summary>Скриншоты</summary>

      | Было | Стало |
      |:-:|:-:|
      |![Screenshot from 2023-12-12 15-03-53](https://github.com/hexlet-codebattle/codebattle/assets/37400913/b0f81bef-c138-478a-a883-5b817a8600aa)|![Screenshot from 2023-12-12 13-31-40](https://github.com/hexlet-codebattle/codebattle/assets/37400913/94c4a625-e006-4d6c-aa8c-e6dc07d1cc6c)|
    </details>