### PR TITLE
fix next items load for infinite horizontal scroll

### DIFF
--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -140,6 +140,22 @@ em-emoji-picker {
   max-height: 100vh;
 }
 
+.top-0 {
+  top: 0;
+}
+
+.start-0 {
+  left: 0;
+}
+
+.end-0 {
+  right: 0;
+}
+
+.z-3 {
+  z-index: 3;
+}
+
 .btn {
   border-radius: unset;
 }

--- a/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
+++ b/services/app/apps/codebattle/assets/js/__tests__/LobbyWidget.test.jsx
@@ -17,10 +17,6 @@ Object.defineProperty(window, 'scrollTo', {
   value: jest.fn(),
 });
 
-jest.mock('@fortawesome/react-fontawesome', () => ({
-  FontAwesomeIcon: 'img',
-}));
-
 jest.mock(
   '../widgets/components/UserInfo',
   () => function UserInfo() {

--- a/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/SideScrollControls.jsx
@@ -5,12 +5,16 @@ import React, {
   useCallback,
 } from 'react';
 
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cn from 'classnames';
+import noop from 'lodash/noop';
 
 const delta = 10;
+const commonClassName = 'position-relative overflow-auto';
+const commonControllsClassName = 'position-absolute h-100 z-3';
 
-function HorizontalScrollControls({ children }) {
+function HorizontalScrollControls({ children, className, onScroll = noop }) {
   const leftButtonRef = useRef(null);
   const scrolledListRef = useRef(null);
   const rightButtonRef = useRef(null);
@@ -18,8 +22,6 @@ function HorizontalScrollControls({ children }) {
   const [scrollLeft, setScrollLeft] = useState(0);
   const [showLeftControl, setShowLeftControl] = useState(false);
   const [showRightControl, setShowRightControl] = useState(children.length > 1);
-
-  const className = 'position-absolute align-items-center h-100';
 
   useEffect(() => {
     if (!scrolledListRef.current || scrolledListRef.current.clientWidth === 0) {
@@ -54,8 +56,9 @@ function HorizontalScrollControls({ children }) {
   }, []);
 
   const handleScroll = useCallback(event => {
+    onScroll(event.currentTarget);
     setScrollLeft(event.currentTarget.scrollLeft);
-  }, [setScrollLeft]);
+  }, [onScroll, setScrollLeft]);
 
   const handleScrollItemsRight = useCallback(() => {
     scrolledListRef.current.scrollBy({
@@ -65,58 +68,40 @@ function HorizontalScrollControls({ children }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const leftControlClassName = cn(
+    commonControllsClassName,
+    'cb-left-scroll-control pr-2 start-0',
+    {
+      'd-block': showLeftControl,
+      'd-none': !showLeftControl,
+    },
+  );
+
+  const rightControlClassName = cn(
+    commonControllsClassName,
+    'cb-right-scroll-control pl-2 top-0 end-0',
+    {
+      'd-block': showRightControl,
+      'd-none': !showRightControl,
+    },
+  );
+
   return (
-    <>
-      <div
-        ref={leftButtonRef}
-        style={{ left: 0, zIndex: 1000 }}
-        className={cn(
-          className,
-          'cb-left-scroll-control pr-2',
-          {
-            'd-flex': showLeftControl,
-            'd-none': !showLeftControl,
-          },
-        )}
-      >
-        <button
-          type="button"
-          className="btn border-0 p-2 h-100"
-          onClick={handleScrollItemsLeft}
-        >
-          <FontAwesomeIcon icon="chevron-left" />
+    <div className={cn(commonClassName, className)}>
+      <div ref={leftButtonRef} className={leftControlClassName}>
+        <button type="button" className="btn border-0 p-2 h-100" onClick={handleScrollItemsLeft}>
+          <FontAwesomeIcon icon={faChevronLeft} />
         </button>
       </div>
-      <div
-        ref={scrolledListRef}
-        onScroll={handleScroll}
-        className="d-flex pb-2 overflow-auto"
-      >
+      <div ref={scrolledListRef} onScroll={handleScroll} className="d-flex pb-2 overflow-auto">
         {children}
       </div>
-      <div
-        ref={rightButtonRef}
-        style={{ right: 0, zIndex: 1000 }}
-        className={cn(
-          className,
-          'cb-right-scroll-control pl-2',
-          {
-            'd-flex': showRightControl,
-            'd-none': !showRightControl,
-          },
-        )}
-      >
-        <button
-          type="button"
-          className="btn border-0 p-2 h-100"
-          onClick={handleScrollItemsRight}
-        >
-          <FontAwesomeIcon
-            icon="chevron-right"
-          />
+      <div ref={rightButtonRef} className={rightControlClassName}>
+        <button type="button" className="btn border-0 p-2 h-100" onClick={handleScrollItemsRight}>
+          <FontAwesomeIcon icon={faChevronRight} />
         </button>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/CompletedGames.jsx
@@ -1,4 +1,6 @@
-import React, { memo, useEffect, useRef } from 'react';
+import React, {
+  memo, useEffect, useRef, useCallback,
+} from 'react';
 
 import cn from 'classnames';
 import moment from 'moment';
@@ -21,11 +23,9 @@ const commonClassName = 'table-responsive d-none d-md-block mvh-100 cb-overflow-
 const InfiniteScrollableGames = memo(({ className, tableClassName, games }) => {
   const dispatch = useDispatch();
   const tableRef = useRef(null);
-  const cardListRef = useRef(null);
 
   useEffect(() => {
     const observableTable = tableRef.current;
-    const observableCards = cardListRef.current;
 
     const onTableScroll = () => {
       const height = tableRef.current.scrollHeight - tableRef.current.parentElement?.offsetHeight;
@@ -36,22 +36,20 @@ const InfiniteScrollableGames = memo(({ className, tableClassName, games }) => {
       }
     };
 
-    const onCardsScroll = () => {
-      const width = cardListRef.current.scrollWidth - cardListRef.current.parentElement?.offsetWidth;
-      const delta = width - cardListRef.current.scrollLeft;
-
-      if (delta < 50) {
-        dispatch(loadNextPage());
-      }
-    };
-
     observableTable.addEventListener('scroll', onTableScroll);
-    observableCards.addEventListener('scroll', onCardsScroll);
 
     return () => {
       observableTable.removeEventListener('scroll', onTableScroll);
-      observableCards.removeEventListener('scroll', onCardsScroll);
     };
+  }, [dispatch]);
+
+  const onCardsScroll = useCallback(cardList => {
+    const width = cardList.scrollWidth - cardList.parentElement?.offsetWidth;
+    const delta = width - cardList.scrollLeft;
+
+    if (delta < 500) {
+      dispatch(loadNextPage());
+    }
   }, [dispatch]);
 
   return (
@@ -97,13 +95,11 @@ const InfiniteScrollableGames = memo(({ className, tableClassName, games }) => {
           </tbody>
         </table>
       </div>
-      <div ref={cardListRef} className="d-flex d-md-none my-2 overflow-auto position-relative">
-        <HorizontalScrollControls>
-          {games.map(game => (
-            <GameCard key={`card-${game.id}`} type="completed" game={game} />
-          ))}
-        </HorizontalScrollControls>
-      </div>
+      <HorizontalScrollControls className="d-md-none my-2" onScroll={onCardsScroll}>
+        {games.map(game => (
+          <GameCard key={`card-${game.id}`} type="completed" game={game} />
+        ))}
+      </HorizontalScrollControls>
     </>
   );
 });

--- a/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/lobby/LobbyWidget.jsx
@@ -116,7 +116,7 @@ const LiveTournaments = ({ tournaments }) => {
   return (
     <div className="table-responsive">
       <h2 className="text-center mt-3">Live tournaments</h2>
-      <div className="d-none d-sm-none d-md-block table-responsive rounded-bottom">
+      <div className="d-none d-md-block table-responsive rounded-bottom">
         <table className="table table-striped">
           <thead className="">
             <tr>
@@ -147,19 +147,15 @@ const LiveTournaments = ({ tournaments }) => {
           </tbody>
         </table>
       </div>
-      <div className="d-none d-sm-block d-md-none d-flex m-2 overflow-auto position-relative">
-        <HorizontalScrollControls>
-          {sortedTournaments.map(
-            tournament => (
-              <TournamentCard
-                key={`card-${tournament.id}`}
-                type="active"
-                tournament={tournament}
-              />
-            ),
-          )}
-        </HorizontalScrollControls>
-      </div>
+      <HorizontalScrollControls className="d-md-none m-2">
+        {sortedTournaments.map(tournament => (
+          <TournamentCard
+            key={`card-${tournament.id}`}
+            type="active"
+            tournament={tournament}
+          />
+        ))}
+      </HorizontalScrollControls>
       <div className="text-center mt-3">
         <a href="/tournaments">
           <u>Tournaments Info</u>
@@ -212,19 +208,15 @@ const CompletedTournaments = ({ tournaments }) => {
           </tbody>
         </table>
       </div>
-      <div className="d-flex d-md-none m-2 overflow-auto position-relative">
-        <HorizontalScrollControls>
-          {sortedTournaments.map(
-            tournament => (
-              <TournamentCard
-                key={`card-${tournament.id}`}
-                type="completed"
-                tournament={tournament}
-              />
-            ),
-          )}
-        </HorizontalScrollControls>
-      </div>
+      <HorizontalScrollControls className="d-md-none m-2">
+        {sortedTournaments.map(tournament => (
+          <TournamentCard
+            key={`card-${tournament.id}`}
+            type="completed"
+            tournament={tournament}
+          />
+        ))}
+      </HorizontalScrollControls>
     </div>
   );
 };
@@ -319,24 +311,18 @@ const ActiveGames = ({
           </tbody>
         </table>
       </div>
-      <div
-        className="d-flex d-md-none m-2 position-relative"
-      >
-        <HorizontalScrollControls>
-          {sortedGames.map(
-            game => isActiveGame(game) && (
-              <GameCard
-                key={`card-${game.id}`}
-                type="active"
-                game={game}
-                currentUserId={currentUserId}
-                isGuest={isGuest}
-                isOnline={isOnline}
-              />
-            ),
-          )}
-        </HorizontalScrollControls>
-      </div>
+      <HorizontalScrollControls className="d-md-none m-2">
+        {sortedGames.map(game => isActiveGame(game) && (
+          <GameCard
+            key={`card-${game.id}`}
+            type="active"
+            game={game}
+            currentUserId={currentUserId}
+            isGuest={isGuest}
+            isOnline={isOnline}
+          />
+        ))}
+      </HorizontalScrollControls>
     </>
   );
 };


### PR DESCRIPTION
Исправлена подгрузка следующего пакета данных для горизонтального "бесконечного" скролла.
В прежней реализации слушатель события `scroll` был навешен на обёртку над блоком, в котором собственно и происходила прокрутка. Поэтому в слушатель событие не попадало и подгрузки при пролистывании до конца списка не происходило.

- добавленные кастомные CSS-классы - из bootstrap v.5. После миграции будут удалены

