### PR TITLE
[#1760] update username error message

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/pages/registration/Registration.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/registration/Registration.jsx
@@ -223,7 +223,7 @@ function SignUp() {
         )
         .min(3, 'Should be from 3 to 16 characters')
         .max(16, 'Should be from 3 to 16 characters')
-        .matches(/^[a-z]+[a-z0-9_-\s{1}][a-z0-9_]+$/i, 'Can contain letters, numbers and underscores and should begin with a Latin letter')
+        .matches(/^[a-z]+[a-z0-9_-\s{1}][a-z0-9_]+$/i, 'Should contain Latin letters only, also can contain numbers and underscores')
         .required('Nickname required'),
       email: Yup
         .string()


### PR DESCRIPTION
Fixes #1760

Update username error message from 'Can contain letters, numbers and underscores and should begin with a Latin letter' to 'Should contain Latin letters only, also can contain numbers and underscores'