### PR TITLE
remove if guest condition for header txt, fix #1955

### DIFF
--- a/services/app/apps/codebattle/lib/codebattle_web/plugs/locale.ex
+++ b/services/app/apps/codebattle/lib/codebattle_web/plugs/locale.ex
@@ -9,12 +9,12 @@ defmodule CodebattleWeb.Plugs.Locale do
 
   def call(conn, _opts) do
     locale =
-    if Application.get_env(:codebattle, :force_locale) do
-      Application.get_env(:codebattle, :default_locale)
-    else
-      conn.params["locale"] || get_session(conn, :locale) ||
+      if Application.get_env(:codebattle, :force_locale) do
         Application.get_env(:codebattle, :default_locale)
-    end
+      else
+        conn.params["locale"] || get_session(conn, :locale) ||
+          Application.get_env(:codebattle, :default_locale)
+      end
 
     conn
     |> put_locale(locale)

--- a/services/app/apps/codebattle/lib/codebattle_web/templates/layout/app.html.heex
+++ b/services/app/apps/codebattle/lib/codebattle_web/templates/layout/app.html.heex
@@ -96,17 +96,10 @@
                   class="my-auto pt-1 pl-2 pl-md-0 pl-lg-0"
                   src="/assets/images/logo.svg"
                 />
-                <%= if @current_user.is_guest do %>
-                  <div class="d-none d-sm-none d-md-flex d-lg-flex text-gray ml-1 pb-1">
-                    <span class="font-weight-bold header-txt">Codebattle</span>
-                    <span class="header-txt">by Hexlet’s community</span>
-                  </div>
-                <% else %>
-                  <div class="d-none d-sm-none d-md-flex d-lg-flex flex-column text-gray ml-1 pb-1">
-                    <span class="font-weight-bold header-txt">Codebattle</span>
-                    <span class="header-txt">by Hexlet’s community</span>
-                  </div>
-                <% end %>
+                <div class="d-none d-sm-none d-md-flex d-lg-flex flex-column text-gray ml-1 pb-1">
+                  <span class="font-weight-bold header-txt">Codebattle</span>
+                  <span class="header-txt">by Hexlet’s community</span>
+                </div>
               </a>
               <%= unless @current_user.is_guest do %>
                 <button


### PR DESCRIPTION
Fixes #1955 

Увидел, что в шаблоне оба блока внутри if выводятся одинаоков, но для гостя почему-то не выводится `flex-column` стиль. Тк разницы нет, удалил условие и оставил только один вариант, содержащий `flex-column`


![image](https://github.com/user-attachments/assets/a1f4f3ad-c05e-4546-8234-c8f11163e397)
