### PR TITLE
Remove semicolon from golang solution generator template

### DIFF
--- a/services/app/apps/codebattle/test/docker_execution/golang_test.exs
+++ b/services/app/apps/codebattle/test/docker_execution/golang_test.exs
@@ -57,7 +57,7 @@ defmodule Codebattle.DockerExecution.GolangTest do
     Mix.Shell.Process.flush()
 
     Phoenix.ChannelTest.push(socket1, "check_result", %{
-      editor_text: "package main;\n\nfunc solution(a int64, b int64) int64 {\n\treturn a - b\n}",
+      editor_text: "package main\n\nfunc solution(a int64, b int64) int64 {\n\treturn a - b\n}",
       lang_slug: "golang"
     })
 
@@ -89,7 +89,7 @@ defmodule Codebattle.DockerExecution.GolangTest do
     Phoenix.ChannelTest.push(socket1, "editor:data", %{editor_text: "test", lang_slug: "js"})
 
     Phoenix.ChannelTest.push(socket1, "check_result", %{
-      editor_text: "package main;\n\nfunc solution(a int64, b int64) int64 {\n\treturn a + b\n}",
+      editor_text: "package main\n\nfunc solution(a int64, b int64) int64 {\n\treturn a + b\n}",
       lang_slug: "golang"
     })
 

--- a/services/app/apps/runner/lib/runner/languages.ex
+++ b/services/app/apps/runner/lib/runner/languages.ex
@@ -358,7 +358,7 @@ defmodule Runner.Languages do
       checker_file_name: "checker.go",
       docker_image: "codebattle/golang:1.22.1",
       solution_template: """
-      package main;
+      package main
       // import "fmt"
 
       func solution(<%= arguments %>)<%= expected %> {

--- a/services/app/apps/runner/test/runner/solution_generator_test.exs
+++ b/services/app/apps/runner/test/runner/solution_generator_test.exs
@@ -50,7 +50,7 @@ defmodule Runner.SolutionGeneratorTest do
   """
 
   @golang_expected """
-  package main;
+  package main
   // import "fmt"
 
   func solution(a int64, text string, b float64, c bool, nested_hash_of_string map[string]string, nested_array_of_string []string, nested_array_of_array_of_strings [][]string) []string {


### PR DESCRIPTION
Hey there! Thanks for this awesome project.

I've noticed that golang solution template generated by the solution generator has an extra semicolon after the package name.

You can find a bug reproduction in [go plaground](https://go.dev/play/p/cocmh0Lvgrg?v=goprev). When you click run the go playground will format the code and drop the semicolon.

Thank you!