### PR TITLE
Fix issue #1979/Auto scroll to latest message

### DIFF
--- a/services/app/apps/codebattle/assets/css/style.scss
+++ b/services/app/apps/codebattle/assets/css/style.scss
@@ -2367,3 +2367,18 @@ a:hover {
 .cb-scrollable-menu-dropdown-chat {
   max-height: 400px
 }
+
+.scroll-button {
+  background-image: url('../static/images/arrowDown.svg');
+  width: 45px;
+  height: 45px;
+  bottom: 65px;
+  right: 15%;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.scroll-button.invisible {
+  display: none;
+}

--- a/services/app/apps/codebattle/assets/js/widgets/components/Messages.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/components/Messages.jsx
@@ -1,5 +1,6 @@
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef, useLayoutEffect, useState } from 'react';
 
+import cn from 'classnames';
 // import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import useStayScrolled from '../utils/useStayScrolled';
@@ -16,13 +17,36 @@ const getKey = (id, time, name, index) => {
 
 function Messages({ messages, displayMenu = () => {}, disabled = false }) {
   const listRef = useRef();
-
-  const { stayScrolled /* , scrollBottom */ } = useStayScrolled(listRef);
+  const minScrollHeight = 20;
+  const [scrollHeight, setScrollHeight] = useState(0);
+  const [isScrollButtonVisible, setIsScrollButtonVisible] = useState(false);
+  const { stayScrolled, scrollBottom } = useStayScrolled(listRef);
   // Typically you will want to use stayScrolled or scrollBottom inside
   // useLayoutEffect, because it measures and changes DOM attributes (scrollTop) directly
   useLayoutEffect(() => {
-    stayScrolled();
-  }, [messages.length, stayScrolled]);
+    if (scrollHeight > minScrollHeight) {
+      stayScrolled();
+      setIsScrollButtonVisible(true);
+    } else {
+      scrollBottom();
+      setIsScrollButtonVisible(false);
+    }
+  }, [messages.length, stayScrolled, scrollBottom]);
+
+  const scrollHandler = e => {
+    const chatContainer = e.target;
+    const chatScrollHeight = chatContainer.scrollHeight - chatContainer.scrollTop - chatContainer.clientHeight;
+
+    if (chatScrollHeight < minScrollHeight) {
+      setIsScrollButtonVisible(false);
+    }
+
+    setScrollHeight(chatScrollHeight);
+  };
+
+  const scrollButtonClass = cn('scroll-button', 'position-absolute', 'rounded-circle', 'bg-secondary', 'p-0', 'border-0', {
+    invisible: !isScrollButtonVisible,
+  });
 
   if (disabled) {
     return (
@@ -40,6 +64,7 @@ function Messages({ messages, displayMenu = () => {}, disabled = false }) {
       <ul
         ref={listRef}
         className="overflow-auto pt-0 pl-3 pr-2 position-relative cb-messages-list flex-grow-1"
+        onScroll={scrollHandler}
       >
         {messages.map((message, index) => {
           const {
@@ -62,6 +87,12 @@ function Messages({ messages, displayMenu = () => {}, disabled = false }) {
           );
         })}
       </ul>
+      <button
+        type="button"
+        className={scrollButtonClass}
+        onClick={scrollBottom}
+        aria-label="Scroll to bottom"
+      />
     </>
   );
 }

--- a/services/app/apps/codebattle/assets/static/images/arrowDown.svg
+++ b/services/app/apps/codebattle/assets/static/images/arrowDown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#e5e5e5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 9.25-7.0 7.0-7.0-7.0" />
+</svg>


### PR DESCRIPTION
## Task
Bug #1992 :  Отсутствует автоматическая прокрутка к последнему сообщению в чате

## Changes
- Добавил обработчик скролла чата. При каждом скролле сохраняем высоту скролла, чтобы от него отталкиваться.
- Добавил кнопку скролла чата к последнему сообщению. Кнопка появляется при появлении нового сообщения, если был минимальный скролл. Исчезает, как доходит до значений минимального скролла.
- Поправил алгоритм useLayoutEffect исходя из обновлений.

![image](https://github.com/user-attachments/assets/2b2fe383-8225-4001-8b00-7f83987570a1)

@ReDBrother 