### PR TITLE
Fix bug #2083 Filtering by tags doesn't work

### DIFF
--- a/services/app/apps/codebattle/lib/codebattle/task.ex
+++ b/services/app/apps/codebattle/lib/codebattle/task.ex
@@ -195,12 +195,19 @@ defmodule Codebattle.Task do
     !result
   end
 
-  @spec get_task_by_tags_for_user(User.t(), list(String.t()), String.t()) :: t() | nil
-  def get_task_by_tags_for_user(user, tags, level) do
-    __MODULE__
+  @spec get_task_by_tags_for_user(User.t(), list(String.t()), String.t() | nil) :: t() | nil
+  def get_task_by_tags_for_user(user, tags, level \\ nil) do
+    query = __MODULE__
     |> filter_visibility(user)
-    |> where([t], t.level == ^level)
     |> where([t], fragment("? @> ?", t.tags, ^tags))
+
+    query = if level do
+      query |> where([t], t.level == ^level)
+    else
+      query
+    end
+
+    query
     |> order_by(fragment("RANDOM()"))
     |> limit(1)
     |> Repo.one()

--- a/services/app/apps/codebattle/lib/codebattle/task.ex
+++ b/services/app/apps/codebattle/lib/codebattle/task.ex
@@ -195,10 +195,11 @@ defmodule Codebattle.Task do
     !result
   end
 
-  @spec get_task_by_tags_for_user(User.t(), list(String.t())) :: t() | nil
-  def get_task_by_tags_for_user(user, tags) do
+  @spec get_task_by_tags_for_user(User.t(), list(String.t()), String.t()) :: t() | nil
+  def get_task_by_tags_for_user(user, tags, level) do
     __MODULE__
     |> filter_visibility(user)
+    |> where([t], t.level == ^level)
     |> where([t], fragment("? @> ?", t.tags, ^tags))
     |> order_by(fragment("RANDOM()"))
     |> limit(1)

--- a/services/app/apps/codebattle/lib/codebattle_web/channels/lobby_channel.ex
+++ b/services/app/apps/codebattle/lib/codebattle_web/channels/lobby_channel.ex
@@ -124,7 +124,8 @@ defmodule CodebattleWeb.LobbyChannel do
   end
 
   defp maybe_add_task(params, %{"task_tags" => task_tags}, user) when length(task_tags) > 0 do
-    case Codebattle.Task.get_task_by_tags_for_user(user, task_tags) do
+    level = Map.get(params, :level)
+    case Codebattle.Task.get_task_by_tags_for_user(user, task_tags, level) do
       nil -> params
       task -> Map.put(params, :task, task)
     end


### PR DESCRIPTION
## Brief
На стороне бэка не учитывался уровень задачи, когда мы активировали фильтр по тегам. Из-за этого пул задач состоял из всех уровней.

## Task
Fixes #2083 Filtering tasks by tags does not work

## Changes
Добавил учет уровня в функцию get_task_by_tags_for_user