### PR TITLE
Issue#1707: add special character requirement in password validation

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/formik/index.js
+++ b/services/app/apps/codebattle/assets/js/widgets/formik/index.js
@@ -74,6 +74,7 @@ const schemas = {
         .matches(/^\S*$/, 'Can\'t contain empty symbols')
         .min(6, 'Should be from 6 to 16 characters')
         .max(16, 'Should be from 6 to 16 characters')
+        .matches(/[!@#$%^&*(),.?":{}|<>]/, 'Should contain at least one special character')
         .required('Password required'),
       passwordConfirmation: Yup
         .string()


### PR DESCRIPTION
## Task
Issue #1707 

## Description
Added a requirement that users must include at least one special character in their password.

## Changes
Updated the password validation in the signUp schema by adding a regex check:
```javascript
.matches(/[!@#$%^&*(),.?":{}|<>]/, 'Should contain at least one special character')
```