### PR TITLE
Add Username contains placeholder to input in User rating

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/pages/rating/RatingList.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/rating/RatingList.jsx
@@ -170,7 +170,7 @@ function UsersRating() {
           <input
             type="text"
             className="form-control"
-            placeholder="Username"
+            placeholder="Username contains…"
             aria-label="Username"
             aria-describedby="basic-addon1"
             value={filterParams.name}


### PR DESCRIPTION
Fixes #2043
Added "Username contains…" to search input in User rating. “Search by name contains…” does not fit in input length.