### PR TITLE
Use mutable* and remove explicit type declaration for default values (Kotlin)

### DIFF
--- a/services/app/apps/runner/lib/runner/languages.ex
+++ b/services/app/apps/runner/lib/runner/languages.ex
@@ -327,7 +327,7 @@ defmodule Runner.Languages do
       import kotlin.collections.*
 
       fun solution(<%= arguments %>):<%= expected %> {
-        val ans: <%= expected %> = <%= default_value %>
+        var ans = <%= default_value %>
         return ans
       }
       // <%= comment %>
@@ -337,9 +337,9 @@ defmodule Runner.Languages do
         "integer" => "0",
         "float" => "0.1",
         "string" => "\"value\"",
-        "array" => "listOf(<%= value %>)",
+        "array" => "mutableListOf(<%= value %>)",
         "boolean" => "true",
-        "hash" => "mapOf(\"key\" to <%= value %>)"
+        "hash" => "mutableMapOf(\"key\" to <%= value %>)"
       },
       expected_template: " <%= type %>",
       types: %{


### PR DESCRIPTION
- Changed `listOf` to `mutableListOf` and `mapOf` to `mutableMapOf` for default array and hash values to allow mutation.
- Removed explicit type declaration (`val ans: <type>`) in favor of type inference with `var`.
