### PR TITLE
fixed discord auth

### DIFF
--- a/services/app/apps/codebattle/lib/codebattle/auth/discord.ex
+++ b/services/app/apps/codebattle/lib/codebattle/auth/discord.ex
@@ -62,7 +62,6 @@ defmodule Codebattle.Auth.Discord do
     @discord_token_url
     |> Req.post!(opts)
     |> Map.get(:body)
-    |> URI.decode_query()
     |> check_authenticated()
   end
 


### PR DESCRIPTION
Fixes #2176
## Fix Discord OAuth crash on token exchange

**Problem:**  
Discord OAuth flow crashed with a `FunctionClauseError` because `Req.post!` returned a map, but we tried to decode it using `URI.decode_query/1`, which expects a string.

**Fix:**  
Removed `URI.decode_query/1` and handled the decoded JSON map directly.

