### PR TITLE
Fix issue #2178: overlaps UI elements

### DIFF
--- a/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorResultIcon.jsx
+++ b/services/app/apps/codebattle/assets/js/widgets/pages/game/EditorResultIcon.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 function EditorResultIcon({ children, mode = 'default' }) {
   const style = mode === 'default' ? {
-    bottom: '5%',
+    bottom: '11%',
     right: '5%',
     opacity: '0.5',
     zIndex: '100',
   } : {
-    bottom: '5%',
+    bottom: '11%',
     right: '5%',
     opacity: '0.5',
     zIndex: '100',


### PR DESCRIPTION
## Task
Bug #2178  :  Trophy image overlaps UI elements after losing bot battle

## Changes
Сдвинул блок повыше, чтобы не перекрывал другие элементы.

![Снимок экрана 2025-06-18 004836](https://github.com/user-attachments/assets/44148c9a-7eac-4ef1-9e23-0957350eff96)

@ReDBrother 