### PR TITLE
Fix password validation to require letter or number

### DIFF
--- a/apps/codebattle/assets/js/__fixtures__/signUpData.json
+++ b/apps/codebattle/assets/js/__fixtures__/signUpData.json
@@ -86,6 +86,12 @@
       "password"
     ],
     [
+      "password validation: only special characters",
+      "!@#$%&*?",
+      "Should contain at least one letter or number",
+      "password"
+    ],
+    [
       "password validation: long password",
       "11111111111111111",
       "Should be from 6 to 16 characters",

--- a/apps/codebattle/assets/js/widgets/formik/index.js
+++ b/apps/codebattle/assets/js/widgets/formik/index.js
@@ -66,6 +66,7 @@ const schemas = {
       .matches(/^\S*$/, "Can't contain empty symbols")
       .min(6, "Should be from 6 to 16 characters")
       .max(16, "Should be from 6 to 16 characters")
+      .matches(/[a-zA-Z0-9]/, "Should contain at least one letter or number")
       .matches(/[!@#$%^&*(),.?":{}|<>]/, "Should contain at least one special character")
       .required("Password required"),
     passwordConfirmation: Yup.string()


### PR DESCRIPTION
The signup password schema requires at least one special character but does not require any letter or number, so `"!@#$%&*?"` passes validation even though the user-facing error message states that passwords must consist of "numbers/letters + special characters" (issue #2240).

Adds one matcher to `apps/codebattle/assets/js/widgets/formik/index.js` so the rule now matches the error message: at least one alphanumeric character plus at least one special character. A fixture entry for the only-special-characters case is added to `apps/codebattle/assets/js/__fixtures__/signUpData.json` so the existing `Registration.test.jsx` data-driven block exercises the new branch.

## Testing

- `cd apps/codebattle && npx --no-install jest` -- all 60 frontend tests pass, including the new `password validation: only special characters` case.
- `cd apps/codebattle && npx --no-install oxfmt --check assets/js/widgets/formik/index.js` -- clean.
- `cd apps/codebattle && npx --no-install oxlint assets/js/widgets/formik/index.js` -- 0 warnings, 0 errors.

Fixes #2240