### PR TITLE
fix: return validation error instead of 500 for out-of-range task_ids

### DIFF
--- a/apps/codebattle/lib/codebattle/forms/task_pack.ex
+++ b/apps/codebattle/lib/codebattle/forms/task_pack.ex
@@ -6,6 +6,8 @@ defmodule Codebattle.TaskPackForm do
   alias Codebattle.Repo
   alias Codebattle.TaskPack
 
+  @task_id_range 1..2_147_483_647
+
   def create(params, user) do
     new_params = Map.merge(params, %{"state" => "draft", "creator_id" => user.id})
 
@@ -51,7 +53,15 @@ defmodule Codebattle.TaskPackForm do
       |> Enum.map(&String.trim/1)
       |> Enum.map(&String.to_integer/1)
 
-    put_change(changeset, :task_ids, task_ids)
+    if Enum.all?(task_ids, &(&1 in @task_id_range)) do
+      put_change(changeset, :task_ids, task_ids)
+    else
+      add_error(
+        changeset,
+        :task_ids,
+        "Please provide integers between 1 and 2147483647 with comma separated values"
+      )
+    end
   rescue
     _ ->
       add_error(changeset, :task_ids, "Please provide only integers with comma separated values")

--- a/apps/codebattle/test/codebattle_web/controllers/task_pack_controller_test.exs
+++ b/apps/codebattle/test/codebattle_web/controllers/task_pack_controller_test.exs
@@ -113,6 +113,80 @@ defmodule CodebattleWeb.TaskPackControllerTest do
            } = task_pack
   end
 
+  test ".create with non-numeric task ids", %{conn: conn} do
+    user = insert(:user)
+
+    params = %{
+      "name" => "mega_pack",
+      "task_ids" => "It is string",
+      "visibility" => "public"
+    }
+
+    conn =
+      conn
+      |> put_session(:user_id, user.id)
+      |> post(Routes.task_pack_path(conn, :create), task_pack: params)
+
+    response = html_response(conn, 200)
+
+    assert response =~ "Create your own task pack"
+    assert response =~ "Please provide only integers with comma separated values"
+  end
+
+  test ".create with out-of-range task ids", %{conn: conn} do
+    user = insert(:user)
+
+    params = %{
+      "name" => "mega_pack",
+      "task_ids" => "999999999999999999",
+      "visibility" => "public"
+    }
+
+    conn =
+      conn
+      |> put_session(:user_id, user.id)
+      |> post(Routes.task_pack_path(conn, :create), task_pack: params)
+
+    response = html_response(conn, 200)
+
+    assert response =~ "Create your own task pack"
+
+    assert response =~
+             "Please provide integers between 1 and 2147483647 with comma separated values"
+  end
+
+  test ".create validates task id range boundaries", %{conn: conn} do
+    user = insert(:user)
+
+    conn = put_session(conn, :user_id, user.id)
+
+    valid_conn =
+      post(conn, Routes.task_pack_path(conn, :create),
+        task_pack: %{
+          "name" => "max_task_id_pack",
+          "task_ids" => "2147483647",
+          "visibility" => "public"
+        }
+      )
+
+    assert %{id: id} = redirected_params(valid_conn)
+    assert %{task_ids: [2_147_483_647]} = Codebattle.TaskPack.get!(id)
+
+    Enum.each(["0", "1,2147483648,3"], fn task_ids ->
+      invalid_conn =
+        post(conn, Routes.task_pack_path(conn, :create),
+          task_pack: %{
+            "name" => "invalid_task_id_pack",
+            "task_ids" => task_ids,
+            "visibility" => "public"
+          }
+        )
+
+      assert html_response(invalid_conn, 200) =~
+               "Please provide integers between 1 and 2147483647 with comma separated values"
+    end)
+  end
+
   test ".update", %{conn: conn} do
     user = insert(:user)
     task_pack = insert(:task_pack, creator_id: user.id)
@@ -134,6 +208,50 @@ defmodule CodebattleWeb.TaskPackControllerTest do
     task_pack = Codebattle.TaskPack.get!(id)
 
     assert %{name: "new_mega_task_pack", task_ids: [22]} = task_pack
+  end
+
+  test ".update with non-numeric task ids", %{conn: conn} do
+    user = insert(:user)
+    task_pack = insert(:task_pack, creator_id: user.id)
+
+    params = %{
+      "name" => "new_mega_task_pack",
+      "task_ids" => "It is string",
+      "visibility" => "public"
+    }
+
+    conn =
+      conn
+      |> put_session(:user_id, user.id)
+      |> patch(Routes.task_pack_path(conn, :update, task_pack), task_pack: params)
+
+    response = html_response(conn, 200)
+
+    assert response =~ "Edit task pack"
+    assert response =~ "Please provide only integers with comma separated values"
+  end
+
+  test ".update with out-of-range task ids", %{conn: conn} do
+    user = insert(:user)
+    task_pack = insert(:task_pack, creator_id: user.id)
+
+    params = %{
+      "name" => "new_mega_task_pack",
+      "task_ids" => "999999999999999999",
+      "visibility" => "public"
+    }
+
+    conn =
+      conn
+      |> put_session(:user_id, user.id)
+      |> patch(Routes.task_pack_path(conn, :update, task_pack), task_pack: params)
+
+    response = html_response(conn, 200)
+
+    assert response =~ "Edit task pack"
+
+    assert response =~
+             "Please provide integers between 1 and 2147483647 with comma separated values"
   end
 
   test ".activate", %{conn: conn} do


### PR DESCRIPTION
## Summary
Saving the "Create your own task pack" form with an out-of-range task id now shows an inline validation message instead of a 500. Ids like `999999999999999999` parse fine in Elixir's arbitrary-precision integers, pass changeset validation, and then blow up inside `Repo.insert` with a Postgrex "integer out of range" error; the form now rejects them at cast time.

## Why this matters
Reported in #1646 with three independent reproductions (2024-01, 2024-03, and 2026-07-06 on commit 2acd190). `Codebattle.TaskPackForm.cast_task_ids/2` already rescues `String.to_integer/1` failures for non-numeric input, but numeric input beyond PostgreSQL's int4 range reached the database and surfaced as a 500. The same path existed for update.

## Changes
- `cast_task_ids/2` in `apps/codebattle/lib/codebattle/forms/task_pack.ex` validates every parsed id is a positive integer within int4 range (1..2_147_483_647) and adds a changeset error in the same user-facing style as the existing parse-error message. The existing non-numeric rescue is unchanged, and no controller changes were needed: `create/2` and `update/2` already re-render the form when the changeset carries errors.

## Testing
Controller tests cover the non-numeric string case and the out-of-range integer case for both create and update, asserting the form re-renders with the validation message rather than raising.

Fixes #1646
